### PR TITLE
Add tool cost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,28 @@ Recoverable issues raise `CostEstimateError` with a clear message (missing prici
 
 ## Troubleshooting
 
-- **“Pricing not found”** → confirm row exists in the CSV; call `refresh_pricing()`.  
+- **"Pricing not found"** → confirm row exists in the CSV; call `refresh_pricing()`.  
 - **`cached_tokens = 0`** → ensure `include_usage_details=True` (classic) or `stream_options={"include_usage": True}` (streaming).  
 - **Model string has no date** → the latest row with `date ≤ today` is used.
+
+---
+
+## Running Tests
+
+To run the test suite:
+
+```bash
+# Install test dependencies
+pip install -r requirements-dev.txt
+
+# Run tests
+pytest tests/ -v
+
+# Run with coverage (if pytest-cov is installed)
+pytest tests/ --cov=openai_cost_calculator --cov-report=html
+```
+
+The test suite includes unit tests for cost calculation, integration tests for the estimation API, and tests for pricing management and tool cost functionality.
 
 ---
 

--- a/openai_cost_calculator/__init__.py
+++ b/openai_cost_calculator/__init__.py
@@ -34,7 +34,8 @@ from .estimate import estimate_cost, estimate_cost_typed, CostEstimateError
 from .core import calculate_cost_typed
 from .pricing import (
     add_pricing_entry, add_pricing_entries, clear_local_pricing,
-    set_offline_mode, refresh_pricing
+    set_offline_mode, refresh_pricing,
+    add_tool_pricing, add_tool_pricings, clear_tool_pricing, load_tool_pricing
 )
 from .types import CostBreakdown
 
@@ -47,6 +48,10 @@ __all__ = [
     "add_pricing_entries",
     "clear_local_pricing",
     "set_offline_mode",
+    "add_tool_pricing",
+    "add_tool_pricings",
+    "clear_tool_pricing",
+    "load_tool_pricing",
     "CostEstimateError",
     "CostBreakdown"
 ]

--- a/openai_cost_calculator/core.py
+++ b/openai_cost_calculator/core.py
@@ -12,7 +12,7 @@ def _usd(value: float) -> str:
     return str(Decimal(value).quantize(Decimal("0.00000001"), rounding=ROUND_HALF_UP))
 
 
-def _calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
+def _calculate_cost_typed(usage: dict, rates: dict, tool_usage: dict = None, tool_pricing: dict = None) -> CostBreakdown:
     """
     Internal function that performs cost calculation using Decimal arithmetic
     and returns a strongly-typed CostBreakdown dataclass.
@@ -33,6 +33,22 @@ def _calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
             "cached_input_price" : float   or None
             "output_price"       : float   (USD / 1M tokens)
         }
+    
+    tool_usage
+        {
+            "WebSearchTool": 2,
+            "FileSearchTool": 1,
+            ...
+        }
+        Optional. Dict mapping tool names to call counts. Defaults to empty dict.
+    
+    tool_pricing
+        {
+            "WebSearchTool": 0.01,
+            "FileSearchTool": 0.05,
+            ...
+        }
+        Optional. Dict mapping tool names to price per call (USD). Defaults to empty dict.
 
     Returns
     -------
@@ -63,17 +79,26 @@ def _calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
     prompt_cached_cost = (Decimal(str(cached_prompt)) / million) * cached_input_price
     completion_cost = (Decimal(str(usage["completion_tokens"])) / million) * output_price
     
-    total = prompt_uncached_cost + prompt_cached_cost + completion_cost
+    # Calculate tool costs
+    tool_cost = Decimal("0")
+    if tool_usage and tool_pricing:
+        for tool_name, call_count in tool_usage.items():
+            if tool_name in tool_pricing and call_count > 0:
+                price_per_call = Decimal(str(tool_pricing[tool_name]))
+                tool_cost += Decimal(str(call_count)) * price_per_call
+    
+    total = prompt_uncached_cost + prompt_cached_cost + completion_cost + tool_cost
 
     return CostBreakdown(
         prompt_cost_uncached=prompt_uncached_cost,
         prompt_cost_cached=prompt_cached_cost,
         completion_cost=completion_cost,
+        tool_cost=tool_cost,
         total_cost=total
     )
 
 
-def calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
+def calculate_cost_typed(usage: dict, rates: dict, tool_usage: dict = None, tool_pricing: dict = None) -> CostBreakdown:
     """
     Calculate costs and return a strongly-typed CostBreakdown dataclass.
     
@@ -93,6 +118,22 @@ def calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
             "cached_input_price" : float   or None
             "output_price"       : float   (USD / 1M tokens)
         }
+    
+    tool_usage
+        {
+            "WebSearchTool": 2,
+            "FileSearchTool": 1,
+            ...
+        }
+        Optional. Dict mapping tool names to call counts. Defaults to empty dict.
+    
+    tool_pricing
+        {
+            "WebSearchTool": 0.01,
+            "FileSearchTool": 0.05,
+            ...
+        }
+        Optional. Dict mapping tool names to price per call (USD). Defaults to empty dict.
 
     Returns
     -------
@@ -101,19 +142,22 @@ def calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
         - prompt_cost_uncached: Decimal
         - prompt_cost_cached: Decimal  
         - completion_cost: Decimal
+        - tool_cost: Decimal
         - total_cost: Decimal
         
     Examples
     --------
     >>> usage = {"prompt_tokens": 1000, "completion_tokens": 500, "cached_tokens": 100}
     >>> rates = {"input_price": 0.5, "cached_input_price": 0.25, "output_price": 1.0}
-    >>> cost = calculate_cost_typed(usage, rates)
-    >>> cost.total_cost  # Decimal('0.00095000')
+    >>> tool_usage = {"WebSearchTool": 2}
+    >>> tool_pricing = {"WebSearchTool": 0.01}
+    >>> cost = calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
+    >>> cost.total_cost  # Decimal('0.02095000')
     """
-    return _calculate_cost_typed(usage, rates)
+    return _calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
 
 
-def calculate_cost(usage: dict, rates: dict) -> dict:
+def calculate_cost(usage: dict, rates: dict, tool_usage: dict = None, tool_pricing: dict = None) -> dict:
     """
     Parameters
     ----------
@@ -131,6 +175,12 @@ def calculate_cost(usage: dict, rates: dict) -> dict:
             "cached_input_price" : float   or None
             "output_price"       : float   (USD / 1M tokens)
         }
+    
+    tool_usage
+        Optional. Dict mapping tool names to call counts. Defaults to empty dict.
+    
+    tool_pricing
+        Optional. Dict mapping tool names to price per call (USD). Defaults to empty dict.
 
     Returns
     -------
@@ -139,6 +189,7 @@ def calculate_cost(usage: dict, rates: dict) -> dict:
             "prompt_cost_uncached": "...",
             "prompt_cost_cached"  : "...",
             "completion_cost"     : "...",
+            "tool_cost"           : "...",
             "total_cost"          : "..."
         }
         
@@ -148,5 +199,5 @@ def calculate_cost(usage: dict, rates: dict) -> dict:
     consider using calculate_cost_typed() which returns a strongly-typed
     CostBreakdown dataclass.
     """
-    cost_breakdown = _calculate_cost_typed(usage, rates)
+    cost_breakdown = _calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
     return cost_breakdown.as_dict(stringify=True)

--- a/openai_cost_calculator/estimate.py
+++ b/openai_cost_calculator/estimate.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 from typing import Iterable, Any, Dict, Tuple
 
 from .core import calculate_cost_typed
-from .parser import extract_model_details, extract_usage
-from .pricing import load_pricing
+from .parser import extract_model_details, extract_usage, extract_tool_usage
+from .pricing import load_pricing, load_tool_pricing
 from .types import CostBreakdown
 
 
@@ -100,8 +100,12 @@ def estimate_cost_typed(response: Any) -> CostBreakdown:
         details = extract_model_details(chunk.model)
         rates = _find_rates(details["model_name"], details["model_date"])
 
+        # ----------------------------------------------------------- tool usage
+        tool_usage = extract_tool_usage(chunk)
+        tool_pricing = load_tool_pricing()
+
         # -------------------------------------------------------------- cost
-        return calculate_cost_typed(usage, rates)
+        return calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
 
     except Exception as exc:
         raise CostEstimateError(str(exc)) from exc

--- a/openai_cost_calculator/parser.py
+++ b/openai_cost_calculator/parser.py
@@ -80,3 +80,69 @@ def extract_usage(obj: Any) -> Dict[str, int]:
         "completion_tokens": int(completion_tokens),
         "cached_tokens": int(cached_tokens),
     }
+
+
+# --------------------------------------------------------------------------- #
+#   Tool usage parser                                                         #
+# --------------------------------------------------------------------------- #
+def extract_tool_usage(obj: Any) -> Dict[str, int]:
+    """
+    Extract tool call counts from a response object.
+    
+    Works with Responses API response objects that have a `tools` array
+    containing tool definitions. Each tool in the array represents one use.
+    
+    Returns a dict mapping tool type names to call counts:
+        {
+            "WebSearchTool": 1,
+            "FileSearchTool": 1,
+            ...
+        }
+    
+    Tool types are detected by examining the `tools` array, which is the
+    official source for tool usage.
+    
+    Supported tool types:
+    - WebSearchTool
+    - FileSearchTool
+    - ComputerTool
+    - CodeInterpreterTool
+    - HostedMCPTool
+    - ImageGenerationTool
+    - LocalShellTool
+    """
+    tool_counts: Dict[str, int] = {}
+    
+    # Get tools array - this is the official source for tool usage
+    # Handle both dict-like and object-like access
+    if isinstance(obj, dict):
+        tools = obj.get("tools", None)
+    else:
+        tools = getattr(obj, "tools", None)
+    
+    if tools is None:
+        return tool_counts
+    
+    # List of supported tool class names
+    supported_tools = [
+        "WebSearchTool",
+        "FileSearchTool",
+        "ComputerTool",
+        "CodeInterpreterTool",
+        "HostedMCPTool",
+        "ImageGenerationTool",
+        "LocalShellTool",
+    ]
+    
+    # Count each tool occurrence in the tools array
+    for tool in tools:
+        # Convert tool to string representation to check for class names
+        tool_str = str(tool)
+        
+        # Check for tool class names in the string
+        for tool_name in supported_tools:
+            if tool_name in tool_str:
+                tool_counts[tool_name] = tool_counts.get(tool_name, 0) + 1
+                break
+    
+    return tool_counts

--- a/openai_cost_calculator/pricing.py
+++ b/openai_cost_calculator/pricing.py
@@ -27,6 +27,12 @@ _LOCAL_OVERRIDES: Dict[Tuple[str, str], dict] = {}
 _LOCK = threading.RLock()
 _OFFLINE_ONLY = False  # if True, never fetch remote CSV
 
+# Tool pricing: maps tool name to price per call (USD)
+_TOOL_PRICING: Dict[str, float] = {
+    "WebSearchTool": 0.01,      # $10.00 / 1K calls
+    "FileSearchTool": 0.0025,    # $2.50 / 1K calls
+}
+
 def _validate_date_str(date: str) -> None:
     # very lightweight guard
     if not isinstance(date, str) or len(date) != 10:
@@ -152,3 +158,82 @@ def refresh_pricing() -> None:
         return
     _CACHE = _fetch_csv()
     _CACHE_TS = time.time()
+
+
+# --------------------------------------------------------------------------- #
+#   Tool pricing management                                                  #
+# --------------------------------------------------------------------------- #
+def add_tool_pricing(tool_name: str, price_per_call: float, replace: bool = True) -> None:
+    """
+    Register or override pricing for a tool.
+    
+    Parameters
+    ----------
+    tool_name
+        Name of the tool (e.g., "WebSearchTool", "FileSearchTool")
+    price_per_call
+        Price per tool call in USD (e.g., 0.01 for $10.00 / 1K calls)
+    replace
+        If False, raises KeyError if tool already exists
+    
+    Example
+    -------
+    >>> add_tool_pricing("WebSearchTool", 0.01)  # $10.00 / 1K calls
+    >>> add_tool_pricing("FileSearchTool", 0.05)  # $50.00 / 1K calls
+    """
+    if not tool_name or not isinstance(tool_name, str):
+        raise ValueError("tool_name must be a non-empty string")
+    if price_per_call < 0:
+        raise ValueError("price_per_call must be non-negative")
+    
+    with _LOCK:
+        if not replace and tool_name in _TOOL_PRICING:
+            raise KeyError(f"Pricing already exists for tool '{tool_name}'; set replace=True to override.")
+        _TOOL_PRICING[tool_name] = float(price_per_call)
+
+
+def add_tool_pricings(entries: Iterable[Tuple[str, float]], replace: bool = True) -> None:
+    """
+    Bulk add tool pricing entries.
+    
+    Parameters
+    ----------
+    entries
+        Iterable of (tool_name, price_per_call) tuples
+    replace
+        If False, raises KeyError if any tool already exists
+    
+    Example
+    -------
+    >>> add_tool_pricings([
+    ...     ("WebSearchTool", 0.01),
+    ...     ("FileSearchTool", 0.05),
+    ... ])
+    """
+    with _LOCK:
+        for tool_name, price_per_call in entries:
+            if not tool_name or not isinstance(tool_name, str):
+                raise ValueError("tool_name must be a non-empty string")
+            if price_per_call < 0:
+                raise ValueError("price_per_call must be non-negative")
+            if not replace and tool_name in _TOOL_PRICING:
+                raise KeyError(f"Pricing already exists for tool '{tool_name}'; set replace=True to override.")
+            _TOOL_PRICING[tool_name] = float(price_per_call)
+
+
+def clear_tool_pricing() -> None:
+    """Remove all user-added tool pricing (resets to defaults)."""
+    with _LOCK:
+        _TOOL_PRICING.clear()
+        # Restore default tool pricing
+        _TOOL_PRICING["WebSearchTool"] = 0.01      # $10.00 / 1K calls
+        _TOOL_PRICING["FileSearchTool"] = 0.0025    # $2.50 / 1K calls
+
+
+def load_tool_pricing() -> Dict[str, float]:
+    """
+    Returns the current tool pricing map.
+    Keys are tool names, values are price per call in USD.
+    """
+    with _LOCK:
+        return _TOOL_PRICING.copy()

--- a/openai_cost_calculator/types.py
+++ b/openai_cost_calculator/types.py
@@ -11,12 +11,13 @@ class CostBreakdown:
     prompt_cost_uncached: Decimal
     prompt_cost_cached:   Decimal
     completion_cost:      Decimal
+    tool_cost:            Decimal
     total_cost:           Decimal
 
     # -- helpers ------------------------------------------------------------
     def as_dict(self, stringify: bool = True) -> Dict[str, str | Decimal]:
         """
-        Return the four fields as a plain dict.
+        Return the fields as a plain dict.
         * If ``stringify`` (default) ⇒ 8‑dp strings (legacy format)
         * Else ⇒ raw Decimal objects
         """

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -7,7 +7,7 @@ import openai_cost_calculator as occ
 
 from openai_cost_calculator.core import calculate_cost, calculate_cost_typed
 from openai_cost_calculator.estimate import estimate_cost, estimate_cost_typed, CostEstimateError
-from openai_cost_calculator.parser import extract_model_details, extract_usage
+from openai_cost_calculator.parser import extract_model_details, extract_usage, extract_tool_usage
 from openai_cost_calculator.types import CostBreakdown
 
 class _Struct:
@@ -59,6 +59,7 @@ def test_calculate_cost_basic_rounding():
         "prompt_cost_uncached": "0.00080000",   # 800 / 1M * $1
         "prompt_cost_cached"  : "0.00010000",   # 200 / 1M * $0.5
         "completion_cost"     : "0.00400000",   # 2 000 / 1M * $2
+        "tool_cost"           : "0.00000000",   # No tools used
         "total_cost"          : "0.00490000",
     }
 
@@ -76,12 +77,14 @@ def test_calculate_cost_typed_basic():
     assert isinstance(cost_breakdown.prompt_cost_uncached, Decimal)
     assert isinstance(cost_breakdown.prompt_cost_cached, Decimal)
     assert isinstance(cost_breakdown.completion_cost, Decimal)
+    assert isinstance(cost_breakdown.tool_cost, Decimal)
     assert isinstance(cost_breakdown.total_cost, Decimal)
     
     # Verify correct values
     assert cost_breakdown.prompt_cost_uncached == Decimal("0.0008")   # 800 / 1M * $1
     assert cost_breakdown.prompt_cost_cached == Decimal("0.0001")     # 200 / 1M * $0.5
     assert cost_breakdown.completion_cost == Decimal("0.004")         # 2000 / 1M * $2
+    assert cost_breakdown.tool_cost == Decimal("0")                  # No tools used
     assert cost_breakdown.total_cost == Decimal("0.0049")
 
 
@@ -110,11 +113,13 @@ def test_cost_breakdown_as_dict():
     # Test stringify=True (default)
     string_dict = cost_breakdown.as_dict(stringify=True)
     assert all(isinstance(v, str) for v in string_dict.values())
+    assert "tool_cost" in string_dict
     assert string_dict["total_cost"] == "0.00490000"
     
     # Test stringify=False  
     decimal_dict = cost_breakdown.as_dict(stringify=False)
     assert all(isinstance(v, Decimal) for v in decimal_dict.values())
+    assert "tool_cost" in decimal_dict
     assert decimal_dict["total_cost"] == Decimal("0.0049")
 
 
@@ -139,6 +144,50 @@ def test_extract_usage_classic_and_new():
         }
 
 
+def test_extract_tool_usage():
+    """Test tool usage extraction from response objects."""
+    # Test with string representation
+    resp_str = _Struct(
+        tools=["WebSearchTool(type=\"web_search\", ...)", "FileSearchTool(type=\"file_search\", ...)"]
+    )
+    tool_usage = extract_tool_usage(resp_str)
+    assert tool_usage == {"WebSearchTool": 1, "FileSearchTool": 1}
+    
+    # Test with single tool
+    resp_single = _Struct(tools=["WebSearchTool(...)"])
+    tool_usage_single = extract_tool_usage(resp_single)
+    assert tool_usage_single == {"WebSearchTool": 1}
+    
+    # Test with no tools
+    resp_no_tools = _Struct(tools=[])
+    tool_usage_none = extract_tool_usage(resp_no_tools)
+    assert tool_usage_none == {}
+    
+    # Test with missing tools attribute
+    resp_no_attr = _Struct(model="test")
+    tool_usage_missing = extract_tool_usage(resp_no_attr)
+    assert tool_usage_missing == {}
+    
+    # Test with dict-like access
+    resp_dict = {"tools": ["WebSearchTool(...)", "WebSearchTool(...)", "FileSearchTool(...)"]}
+    tool_usage_dict = extract_tool_usage(resp_dict)
+    assert tool_usage_dict == {"WebSearchTool": 2, "FileSearchTool": 1}
+    
+    # Test with all supported tool types
+    resp_all = _Struct(tools=[
+        "WebSearchTool(...)",
+        "FileSearchTool(...)",
+        "ComputerTool(...)",
+        "CodeInterpreterTool(...)",
+        "HostedMCPTool(...)",
+        "ImageGenerationTool(...)",
+        "LocalShellTool(...)",
+    ])
+    tool_usage_all = extract_tool_usage(resp_all)
+    assert len(tool_usage_all) == 7
+    assert all(count == 1 for count in tool_usage_all.values())
+
+
 # --------------------------------------------------------------------------- #
 # Integration tests: estimate_cost                                            #
 # --------------------------------------------------------------------------- #
@@ -149,7 +198,8 @@ def test_estimate_cost_single_response():
     assert all(isinstance(v, str) for v in cost.values())
     total = sum(map(float, (cost["prompt_cost_uncached"],
                             cost["prompt_cost_cached"],
-                            cost["completion_cost"])))
+                            cost["completion_cost"],
+                            cost["tool_cost"])))
     assert float(cost["total_cost"]) == pytest.approx(total)
 
 
@@ -165,10 +215,11 @@ def test_estimate_cost_typed_single_response():
     assert isinstance(cost.prompt_cost_uncached, Decimal)
     assert isinstance(cost.prompt_cost_cached, Decimal)
     assert isinstance(cost.completion_cost, Decimal)
+    assert isinstance(cost.tool_cost, Decimal)
     assert isinstance(cost.total_cost, Decimal)
     
     # Verify total is sum of parts (with Decimal precision)
-    expected_total = cost.prompt_cost_uncached + cost.prompt_cost_cached + cost.completion_cost
+    expected_total = cost.prompt_cost_uncached + cost.prompt_cost_cached + cost.completion_cost + cost.tool_cost
     assert cost.total_cost == expected_total
 
 
@@ -231,6 +282,12 @@ def test_public_api_imports():
     assert hasattr(occ, 'estimate_cost_typed')
     assert hasattr(occ, 'calculate_cost_typed')
     assert hasattr(occ, 'CostBreakdown')
+    
+    # Test that tool pricing functions are available
+    assert hasattr(occ, 'add_tool_pricing')
+    assert hasattr(occ, 'add_tool_pricings')
+    assert hasattr(occ, 'clear_tool_pricing')
+    assert hasattr(occ, 'load_tool_pricing')
     
     # Test that legacy functions are still available
     assert hasattr(occ, 'estimate_cost')
@@ -516,3 +573,258 @@ def test_set_offline_mode_refresh_noop(monkeypatch):
     assert d[("y", "2025-03-03")] == {
         "input_price": 0.2, "cached_input_price": None, "output_price": 0.4
     }
+
+
+# --------------------------------------------------------------------------- #
+# Tool cost calculation tests                                                 #
+# --------------------------------------------------------------------------- #
+def test_calculate_cost_with_tools():
+    """Test cost calculation with tool usage."""
+    usage = {"prompt_tokens": 1_000, "completion_tokens": 500, "cached_tokens": 100}
+    rates = {"input_price": 1.0, "cached_input_price": 0.5, "output_price": 2.0}
+    tool_usage = {"WebSearchTool": 2, "FileSearchTool": 1}
+    tool_pricing = {"WebSearchTool": 0.01, "FileSearchTool": 0.0025}
+    
+    cost = calculate_cost(usage, rates, tool_usage, tool_pricing)
+    
+    # Token costs: (900/1M * $1) + (100/1M * $0.5) + (500/1M * $2) = 0.0009 + 0.00005 + 0.001 = 0.00195
+    # Tool costs: 2 * $0.01 + 1 * $0.0025 = $0.0225
+    assert cost["tool_cost"] == "0.02250000"
+    # Total should include tool costs
+    assert float(cost["total_cost"]) == pytest.approx(0.00195 + 0.0225)
+
+
+def test_calculate_cost_typed_with_tools():
+    """Test typed cost calculation with tool usage."""
+    usage = {"prompt_tokens": 1_000, "completion_tokens": 500, "cached_tokens": 100}
+    rates = {"input_price": 1.0, "cached_input_price": 0.5, "output_price": 2.0}
+    tool_usage = {"WebSearchTool": 1}
+    tool_pricing = {"WebSearchTool": 0.01}
+    
+    cost = calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
+    
+    assert isinstance(cost, CostBreakdown)
+    assert cost.tool_cost == Decimal("0.01")
+    # Token costs: 0.00195, tool cost: 0.01
+    assert cost.total_cost == Decimal("0.00195") + Decimal("0.01")
+
+
+def test_calculate_cost_with_tools_no_pricing():
+    """Test that tools without pricing don't contribute to cost."""
+    usage = {"prompt_tokens": 1_000, "completion_tokens": 500, "cached_tokens": 100}
+    rates = {"input_price": 1.0, "cached_input_price": 0.5, "output_price": 2.0}
+    tool_usage = {"WebSearchTool": 1, "UnknownTool": 5}
+    tool_pricing = {"WebSearchTool": 0.01}  # UnknownTool not in pricing
+    
+    cost = calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
+    
+    # Only WebSearchTool should contribute
+    assert cost.tool_cost == Decimal("0.01")
+    # Token costs: 0.00195, tool cost: 0.01
+    assert cost.total_cost == Decimal("0.00195") + Decimal("0.01")
+
+
+def test_calculate_cost_with_tools_zero_calls():
+    """Test that zero tool calls result in zero tool cost."""
+    usage = {"prompt_tokens": 1_000, "completion_tokens": 500, "cached_tokens": 100}
+    rates = {"input_price": 1.0, "cached_input_price": 0.5, "output_price": 2.0}
+    tool_usage = {"WebSearchTool": 0}
+    tool_pricing = {"WebSearchTool": 0.01}
+    
+    cost = calculate_cost_typed(usage, rates, tool_usage, tool_pricing)
+    
+    assert cost.tool_cost == Decimal("0")
+    # Token costs only: 0.00195
+    assert cost.total_cost == Decimal("0.00195")
+
+
+def test_calculate_cost_with_tools_none():
+    """Test that None tool_usage and tool_pricing work correctly."""
+    usage = {"prompt_tokens": 1_000, "completion_tokens": 500, "cached_tokens": 100}
+    rates = {"input_price": 1.0, "cached_input_price": 0.5, "output_price": 2.0}
+    
+    cost = calculate_cost_typed(usage, rates, None, None)
+    
+    assert cost.tool_cost == Decimal("0")
+    # Token costs only: 0.00195
+    assert cost.total_cost == Decimal("0.00195")
+
+
+# --------------------------------------------------------------------------- #
+# Tool pricing management tests                                               #
+# --------------------------------------------------------------------------- #
+def test_add_tool_pricing():
+    """Test adding tool pricing."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    pricing._TOOL_PRICING.clear()
+    
+    pricing.add_tool_pricing("WebSearchTool", 0.01)
+    pricing.add_tool_pricing("FileSearchTool", 0.0025)
+    
+    tool_pricing = pricing.load_tool_pricing()
+    assert tool_pricing["WebSearchTool"] == 0.01
+    assert tool_pricing["FileSearchTool"] == 0.0025
+
+
+def test_add_tool_pricing_replace():
+    """Test that add_tool_pricing replaces existing pricing by default."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricing("WebSearchTool", 0.01)
+    pricing.add_tool_pricing("WebSearchTool", 0.02, replace=True)
+    
+    tool_pricing = pricing.load_tool_pricing()
+    assert tool_pricing["WebSearchTool"] == 0.02
+
+
+def test_add_tool_pricing_no_replace():
+    """Test that add_tool_pricing raises KeyError when replace=False and tool exists."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricing("WebSearchTool", 0.01)
+    
+    with pytest.raises(KeyError):
+        pricing.add_tool_pricing("WebSearchTool", 0.02, replace=False)
+
+
+def test_add_tool_pricing_validation():
+    """Test validation for add_tool_pricing."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    with pytest.raises(ValueError):
+        pricing.add_tool_pricing("", 0.01)
+    
+    with pytest.raises(ValueError):
+        pricing.add_tool_pricing("WebSearchTool", -0.01)
+
+
+def test_add_tool_pricings():
+    """Test bulk adding tool pricing."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricings([
+        ("WebSearchTool", 0.01),
+        ("FileSearchTool", 0.0025),
+        ("ComputerTool", 0.05),
+    ])
+    
+    tool_pricing = pricing.load_tool_pricing()
+    assert tool_pricing["WebSearchTool"] == 0.01
+    assert tool_pricing["FileSearchTool"] == 0.0025
+    assert tool_pricing["ComputerTool"] == 0.05
+
+
+def test_add_tool_pricings_replace_flag():
+    """Test replace flag in add_tool_pricings."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricings([("WebSearchTool", 0.01)])
+    
+    # Should raise KeyError if replace=False
+    with pytest.raises(KeyError):
+        pricing.add_tool_pricings([("WebSearchTool", 0.02)], replace=False)
+    
+    # Should update if replace=True
+    pricing.add_tool_pricings([("WebSearchTool", 0.02)], replace=True)
+    tool_pricing = pricing.load_tool_pricing()
+    assert tool_pricing["WebSearchTool"] == 0.02
+
+
+def test_clear_tool_pricing():
+    """Test clearing tool pricing and restoring defaults."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricing("CustomTool", 0.1)
+    assert "CustomTool" in pricing.load_tool_pricing()
+    
+    pricing.clear_tool_pricing()
+    tool_pricing = pricing.load_tool_pricing()
+    
+    # Should restore defaults
+    assert "WebSearchTool" in tool_pricing
+    assert "FileSearchTool" in tool_pricing
+    assert tool_pricing["WebSearchTool"] == 0.01
+    assert tool_pricing["FileSearchTool"] == 0.0025
+    assert "CustomTool" not in tool_pricing
+
+
+def test_load_tool_pricing():
+    """Test loading tool pricing."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    # Should return a copy
+    tool_pricing1 = pricing.load_tool_pricing()
+    tool_pricing2 = pricing.load_tool_pricing()
+    
+    assert tool_pricing1 == tool_pricing2
+    assert tool_pricing1 is not tool_pricing2  # Should be a copy
+    
+    # Modifying the copy shouldn't affect the original
+    tool_pricing1["TestTool"] = 0.99
+    tool_pricing3 = pricing.load_tool_pricing()
+    assert "TestTool" not in tool_pricing3
+
+
+# --------------------------------------------------------------------------- #
+# Integration tests: estimate_cost with tools                                 #
+# --------------------------------------------------------------------------- #
+def test_estimate_cost_with_tools(monkeypatch):
+    """Test estimate_cost with tool usage."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    # Set up tool pricing
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricing("WebSearchTool", 0.01)
+    
+    # Create response with tools
+    resp = _classic_response(1_000, 500, 100)
+    resp.tools = ["WebSearchTool(...)"]
+    
+    # Mock tool pricing loading
+    monkeypatch.setattr(occ.pricing, "load_tool_pricing", lambda: {"WebSearchTool": 0.01})
+    
+    cost = estimate_cost(resp)
+    
+    # Should include tool cost
+    assert float(cost["tool_cost"]) > 0
+    assert float(cost["total_cost"]) > float(cost["prompt_cost_uncached"]) + float(cost["prompt_cost_cached"]) + float(cost["completion_cost"])
+
+
+def test_estimate_cost_typed_with_tools(monkeypatch):
+    """Test estimate_cost_typed with tool usage."""
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+    
+    # Set up tool pricing
+    pricing._TOOL_PRICING.clear()
+    pricing.add_tool_pricing("WebSearchTool", 0.01)
+    pricing.add_tool_pricing("FileSearchTool", 0.0025)
+    
+    # Create response with multiple tools
+    resp = _classic_response(1_000, 500, 100)
+    resp.tools = ["WebSearchTool(...)", "FileSearchTool(...)"]
+    
+    # Mock tool pricing loading
+    monkeypatch.setattr(occ.pricing, "load_tool_pricing", lambda: {"WebSearchTool": 0.01, "FileSearchTool": 0.0025})
+    
+    cost = estimate_cost_typed(resp)
+    
+    # Should include tool costs: $0.01 + $0.0025 = $0.0125
+    assert cost.tool_cost == Decimal("0.0125")
+    expected_total = cost.prompt_cost_uncached + cost.prompt_cost_cached + cost.completion_cost + cost.tool_cost
+    assert cost.total_cost == expected_total


### PR DESCRIPTION
This PR adds support for performing tool call cost analysis for OpenAI generations for the following tools:
- Web Search
- File Search

For this PR, I have simply hard-coded the pricing for tool calls into `pricing.py`; my suggestion would be to create a follow-up feature to pull this from a CSV as you do with inference pricing already.

Test coverage has been updated and I believe the updated cases cover all new logic.

Resolves https://github.com/orkunkinay/openai_cost_calculator/issues/5