### PR TITLE
Add agent turn cost tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,38 @@ print(estimate_cost_typed(stream))
 
 ---
 
+## Tracking agent turns
+
+Use `CostTracker` when one user-visible turn can make many OpenAI calls and you
+want a running total.
+
+```python
+from openai import OpenAI
+from openai_cost_calculator import CostTracker
+
+tracker = CostTracker()
+client = tracker.wrap(OpenAI())
+
+with tracker.turn("Refactor auth") as turn:
+    client.chat.completions.create(
+        model="gpt-5.4-mini",
+        messages=[{"role": "user", "content": "Plan the refactor"}],
+    )
+    client.responses.create(
+        model="gpt-5.4-mini",
+        input=[{"role": "user", "content": "Summarize the changes"}],
+    )
+
+print(turn.total_cost)
+print(turn.cost_by_model)
+print(tracker.session_total)
+```
+
+For streaming calls, pass `stream_options={"include_usage": True}` so the final
+usage chunk is available for cost tracking.
+
+---
+
 ## Highlights
 
 - **Typed API:** `CostBreakdown` dataclass with `Decimal` precision  

--- a/openai_cost_calculator/__init__.py
+++ b/openai_cost_calculator/__init__.py
@@ -37,6 +37,7 @@ from .pricing import (
     set_offline_mode, refresh_pricing
 )
 from .types import CostBreakdown
+from .tracker import CostTracker, Turn, CallRecord
 
 __all__ = [
     "estimate_cost", 
@@ -48,5 +49,8 @@ __all__ = [
     "clear_local_pricing",
     "set_offline_mode",
     "CostEstimateError",
-    "CostBreakdown"
+    "CostBreakdown",
+    "CostTracker",
+    "Turn",
+    "CallRecord",
 ]

--- a/openai_cost_calculator/tracker.py
+++ b/openai_cost_calculator/tracker.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal
+import time
+from typing import Any, Callable, Dict, Iterator, List, Optional, Union
+
+from .estimate import estimate_cost_typed
+from .parser import extract_usage
+from .types import CostBreakdown
+
+
+_WRAPPED_SENTINEL = "_openai_cost_calculator_wrapped"
+
+
+@dataclass(frozen=True)
+class CallRecord:
+    """One costed OpenAI API call."""
+
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    cached_tokens: int
+    cost: CostBreakdown
+    timestamp: float
+
+
+class Turn:
+    """Aggregated cost and token usage for one agent turn."""
+
+    def __init__(self, label: Optional[str] = None) -> None:
+        self.label = label
+        self._records: List[CallRecord] = []
+
+    @property
+    def records(self) -> List[CallRecord]:
+        return list(self._records)
+
+    @property
+    def num_calls(self) -> int:
+        return len(self._records)
+
+    @property
+    def total_cost(self) -> Decimal:
+        return sum((record.cost.total_cost for record in self._records), Decimal("0"))
+
+    @property
+    def prompt_tokens(self) -> int:
+        return sum(record.prompt_tokens for record in self._records)
+
+    @property
+    def completion_tokens(self) -> int:
+        return sum(record.completion_tokens for record in self._records)
+
+    @property
+    def cached_tokens(self) -> int:
+        return sum(record.cached_tokens for record in self._records)
+
+    @property
+    def cost_by_model(self) -> Dict[str, Decimal]:
+        costs: Dict[str, Decimal] = {}
+        for record in self._records:
+            costs[record.model] = costs.get(record.model, Decimal("0")) + record.cost.total_cost
+        return costs
+
+    def add(self, record: CallRecord) -> None:
+        self._records.append(record)
+
+    def as_dict(self, stringify: bool = True) -> dict:
+        total_cost: Union[Decimal, str]
+        cost_by_model: Union[Dict[str, Decimal], Dict[str, str]]
+        if stringify:
+            total_cost = f"{self.total_cost:.8f}"
+            cost_by_model = {
+                model: f"{cost:.8f}" for model, cost in self.cost_by_model.items()
+            }
+        else:
+            total_cost = self.total_cost
+            cost_by_model = self.cost_by_model
+
+        return {
+            "label": self.label,
+            "num_calls": self.num_calls,
+            "total_cost": total_cost,
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "cached_tokens": self.cached_tokens,
+            "cost_by_model": cost_by_model,
+        }
+
+
+def _record_source(response: Any) -> Any:
+    if not hasattr(response, "__iter__") or hasattr(response, "model"):
+        return response
+
+    last_usage_chunk = None
+    for chunk in response:
+        if hasattr(chunk, "usage"):
+            last_usage_chunk = chunk
+
+    if last_usage_chunk is None:
+        return response
+    return last_usage_chunk
+
+
+class _TrackedStream:
+    def __init__(self, stream: Any, tracker: "CostTracker") -> None:
+        self._stream = stream
+        self._tracker = tracker
+        self._iterator = iter(stream)
+        self._last_usage_chunk: Optional[Any] = None
+
+    def __iter__(self) -> "_TrackedStream":
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            chunk = next(self._iterator)
+        except StopIteration:
+            if self._last_usage_chunk is not None:
+                self._tracker._record_safely(self._last_usage_chunk)
+                self._last_usage_chunk = None
+            raise
+
+        if hasattr(chunk, "usage") and getattr(chunk, "usage") is not None:
+            self._last_usage_chunk = chunk
+        return chunk
+
+    def close(self) -> None:
+        close = getattr(self._stream, "close", None)
+        if close is not None:
+            close()
+
+    def __enter__(self) -> "_TrackedStream":
+        enter = getattr(self._stream, "__enter__", None)
+        if enter is not None:
+            entered = enter()
+            self._stream = entered
+            self._iterator = iter(entered)
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+        exit_ = getattr(self._stream, "__exit__", None)
+        if exit_ is not None:
+            return exit_(exc_type, exc, tb)
+        return None
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+class CostTracker:
+    """Stateful cost tracker for multi-call agent turns."""
+
+    def __init__(self, on_error: Optional[Callable[[Exception], None]] = None) -> None:
+        self.session_total = Decimal("0")
+        self.turns: List[Turn] = []
+        self.on_error = on_error
+        self._active_turn: Optional[Turn] = None
+
+    @contextmanager
+    def turn(self, label: Optional[str] = None) -> Iterator[Turn]:
+        current = Turn(label)
+        previous = self._active_turn
+        self._active_turn = current
+        try:
+            yield current
+        finally:
+            self._active_turn = previous
+            self.turns.append(current)
+
+    def record(self, response: Any) -> CallRecord:
+        source = _record_source(response)
+        cost = estimate_cost_typed(source)
+        usage = extract_usage(source)
+        record = CallRecord(
+            model=source.model,
+            prompt_tokens=usage["prompt_tokens"],
+            completion_tokens=usage["completion_tokens"],
+            cached_tokens=usage["cached_tokens"],
+            cost=cost,
+            timestamp=time.time(),
+        )
+        if self._active_turn is not None:
+            self._active_turn.add(record)
+        self.session_total += record.cost.total_cost
+        return record
+
+    def wrap(self, client: Any) -> Any:
+        chat_completions = getattr(getattr(client, "chat", None), "completions", None)
+        if chat_completions is not None:
+            self._wrap_create(chat_completions)
+
+        responses = getattr(client, "responses", None)
+        if responses is not None:
+            self._wrap_create(responses)
+
+        return client
+
+    def reset(self) -> None:
+        self.turns.clear()
+        self.session_total = Decimal("0")
+        self._active_turn = None
+
+    def _wrap_create(self, owner: Any) -> None:
+        original = getattr(owner, "create", None)
+        if original is None or getattr(original, _WRAPPED_SENTINEL, False):
+            return
+
+        def wrapped_create(*args: Any, **kwargs: Any) -> Any:
+            response = original(*args, **kwargs)
+            if kwargs.get("stream") is True:
+                return _TrackedStream(response, self)
+
+            self._record_safely(response)
+            return response
+
+        setattr(wrapped_create, _WRAPPED_SENTINEL, True)
+        setattr(owner, "create", wrapped_create)
+
+    def _record_safely(self, response: Any) -> Optional[CallRecord]:
+        try:
+            return self.record(response)
+        except Exception as exc:
+            if self.on_error is not None:
+                self.on_error(exc)
+            return None

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,192 @@
+from decimal import Decimal
+
+import pytest
+
+from openai_cost_calculator import CostTracker
+from openai_cost_calculator.pricing import (
+    add_pricing_entry,
+    clear_local_pricing,
+    set_offline_mode,
+)
+from openai_cost_calculator.tracker import CallRecord
+
+
+class _Struct:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class _Resource:
+    def __init__(self, handler):
+        self.handler = handler
+
+    def create(self, **kwargs):
+        return self.handler(**kwargs)
+
+
+class _FakeClient:
+    def __init__(self, chat_handler=None, responses_handler=None):
+        self.chat = _Struct(completions=_Resource(chat_handler or (lambda **_: None)))
+        self.responses = _Resource(responses_handler or (lambda **_: None))
+
+
+@pytest.fixture(autouse=True)
+def pinned_pricing():
+    clear_local_pricing()
+    set_offline_mode(True)
+    add_pricing_entry(
+        "gpt-test",
+        "2025-01-01",
+        input_price=1.0,
+        output_price=2.0,
+        cached_input_price=0.5,
+    )
+    yield
+    clear_local_pricing()
+    set_offline_mode(False)
+
+
+def _chat_response(prompt_t, completion_t, cached_t=0, model="gpt-test-2025-01-01"):
+    usage = _Struct(
+        prompt_tokens=prompt_t,
+        completion_tokens=completion_t,
+        prompt_tokens_details=_Struct(cached_tokens=cached_t),
+    )
+    return _Struct(model=model, usage=usage)
+
+
+def _responses_response(input_t, output_t, cached_t=0, model="gpt-test-2025-01-01"):
+    usage = _Struct(
+        input_tokens=input_t,
+        output_tokens=output_t,
+        input_tokens_details=_Struct(cached_tokens=cached_t),
+    )
+    return _Struct(model=model, usage=usage)
+
+
+def test_turn_aggregates_multiple_record_calls():
+    tracker = CostTracker()
+
+    with tracker.turn("Implement feature") as turn:
+        first = tracker.record(_chat_response(1_000, 2_000, 100))
+        tracker.record(_responses_response(2_000, 1_000, 500))
+
+    assert isinstance(first, CallRecord)
+    assert turn.num_calls == 2
+    assert turn.prompt_tokens == 3_000
+    assert turn.completion_tokens == 3_000
+    assert turn.cached_tokens == 600
+    assert turn.total_cost == Decimal("0.00870")
+    assert turn.cost_by_model == {"gpt-test-2025-01-01": Decimal("0.00870")}
+    assert turn.as_dict()["total_cost"] == "0.00870000"
+    assert turn.as_dict(stringify=False)["total_cost"] == Decimal("0.00870")
+
+
+def test_session_total_accumulates_across_multiple_turns():
+    tracker = CostTracker()
+
+    with tracker.turn("First"):
+        tracker.record(_chat_response(1_000, 0, 0))
+
+    with tracker.turn("Second"):
+        tracker.record(_chat_response(0, 2_000, 0))
+
+    assert len(tracker.turns) == 2
+    assert tracker.session_total == Decimal("0.005")
+
+
+def test_wrap_auto_records_non_streaming_calls_and_returns_original_response():
+    response = _chat_response(1_000, 2_000, 100)
+    client = _FakeClient(chat_handler=lambda **kwargs: response)
+    tracker = CostTracker()
+
+    wrapped = tracker.wrap(client)
+    with tracker.turn("Chat") as turn:
+        returned = wrapped.chat.completions.create(model="gpt-test")
+
+    assert returned is response
+    assert turn.num_calls == 1
+    assert tracker.session_total == Decimal("0.00495")
+
+
+def test_wrap_auto_records_responses_create():
+    response = _responses_response(1_000, 2_000, 100)
+    client = _FakeClient(responses_handler=lambda **kwargs: response)
+    tracker = CostTracker()
+
+    tracker.wrap(client)
+    with tracker.turn("Responses") as turn:
+        returned = client.responses.create(model="gpt-test")
+
+    assert returned is response
+    assert turn.prompt_tokens == 1_000
+    assert turn.total_cost == Decimal("0.00495")
+
+
+def test_streaming_call_passes_chunks_through_and_records_last_usage_chunk():
+    chunks = [
+        _Struct(model="gpt-test-2025-01-01", delta="start"),
+        _chat_response(1_000, 0, 0),
+        _chat_response(2_000, 3_000, 500),
+    ]
+    client = _FakeClient(chat_handler=lambda **kwargs: iter(chunks))
+    tracker = CostTracker()
+
+    tracker.wrap(client)
+    with tracker.turn("Stream") as turn:
+        stream = client.chat.completions.create(stream=True)
+        returned_chunks = list(stream)
+
+    assert returned_chunks == chunks
+    assert turn.num_calls == 1
+    assert turn.prompt_tokens == 2_000
+    assert turn.completion_tokens == 3_000
+    assert turn.cached_tokens == 500
+    assert turn.total_cost == Decimal("0.00775")
+
+
+def test_nested_turns_attach_to_innermost_and_restore_outer():
+    tracker = CostTracker()
+
+    with tracker.turn("Outer") as outer:
+        tracker.record(_chat_response(1_000, 0, 0))
+        with tracker.turn("Inner") as inner:
+            tracker.record(_chat_response(0, 1_000, 0))
+        tracker.record(_chat_response(2_000, 0, 0))
+
+    assert outer.num_calls == 2
+    assert outer.total_cost == Decimal("0.003")
+    assert inner.num_calls == 1
+    assert inner.total_cost == Decimal("0.002")
+    assert tracker.turns == [inner, outer]
+    assert tracker.session_total == Decimal("0.005")
+
+
+def test_costing_error_in_wrapped_call_does_not_propagate_and_triggers_on_error():
+    errors = []
+    response = _chat_response(10, 10, 0, model="unknown-model-2099-01-01")
+    client = _FakeClient(chat_handler=lambda **kwargs: response)
+    tracker = CostTracker(on_error=errors.append)
+
+    tracker.wrap(client)
+    with tracker.turn("Unknown") as turn:
+        returned = client.chat.completions.create(model="unknown-model")
+
+    assert returned is response
+    assert turn.num_calls == 0
+    assert tracker.session_total == Decimal("0")
+    assert len(errors) == 1
+
+
+def test_double_wrap_does_not_double_count():
+    response = _chat_response(1_000, 0, 0)
+    client = _FakeClient(chat_handler=lambda **kwargs: response)
+    tracker = CostTracker()
+
+    tracker.wrap(client)
+    tracker.wrap(client)
+    with tracker.turn("Double wrap") as turn:
+        client.chat.completions.create()
+
+    assert turn.num_calls == 1
+    assert tracker.session_total == Decimal("0.001")


### PR DESCRIPTION
## Summary
Adds a stateful `CostTracker` API for aggregating OpenAI response costs across multi-call agent turns.
It introduces `CallRecord` and `Turn`, exports the new public classes, and instruments fake OpenAI clients for non-streaming and streaming calls without changing existing estimator APIs.
The README now shows `tracker.wrap(client)` and `with tracker.turn(...)` usage with `gpt-5.4-mini` examples.

## Validation
Ran `.context/venv/bin/python -m pytest` with 35 passing tests and one existing `datetime.utcnow()` deprecation warning.
