### PR TITLE
[codex] Add OpenAI-compatible cost proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,47 @@ usage chunk is available for cost tracking.
 
 ---
 
+## Zero-config tracking with the proxy
+
+Install the optional proxy dependencies:
+
+```bash
+pip install openai-cost-calculator[proxy]
+```
+
+Run the local OpenAI-compatible proxy:
+
+```bash
+openai-cost-calculator proxy --port 8100
+```
+
+Point any OpenAI-compatible agent, IDE, or SDK client at:
+
+```text
+http://127.0.0.1:8100/v1
+```
+
+The proxy forwards requests to `https://api.openai.com/v1` by default, preserving
+the request body and `Authorization` header. To use another OpenAI-compatible
+upstream:
+
+```bash
+openai-cost-calculator proxy --port 8100 --upstream https://example.com/v1
+```
+
+Read accumulated costs at:
+
+```text
+http://127.0.0.1:8100/_occ/costs
+```
+
+For grouping, send `X-OCC-Session` to separate agent sessions and `X-OCC-Turn`
+to group calls within a visible turn. Streaming calls should set
+`stream_options={"include_usage": true}` so the final SSE usage event can be
+costed.
+
+---
+
 ## Highlights
 
 - **Typed API:** `CostBreakdown` dataclass with `Decimal` precision  

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+from typing import Optional, Sequence
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="openai-cost-calculator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    proxy_parser = subparsers.add_parser("proxy", help="Run the local cost proxy")
+    proxy_parser.add_argument("--host", default="127.0.0.1")
+    proxy_parser.add_argument("--port", default=8100, type=int)
+    proxy_parser.add_argument("--upstream", default="https://api.openai.com/v1")
+
+    args = parser.parse_args(argv)
+    if args.command == "proxy":
+        return _run_proxy(args.host, args.port, args.upstream)
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+def _run_proxy(host: str, port: int, upstream: str) -> int:
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise ImportError(
+            "The proxy CLI requires optional web dependencies. Install with "
+            "`pip install openai-cost-calculator[proxy]`."
+        ) from exc
+
+    from openai_cost_calculator.proxy.app import create_app
+
+    app = create_app(upstream=upstream)
+    base = f"http://{host}:{port}"
+    print(f"OpenAI-compatible base_url: {base}/v1")
+    print(f"Cost summary: {base}/_occ/costs")
+    uvicorn.run(app, host=host, port=port)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/openai_cost_calculator/parser.py
+++ b/openai_cost_calculator/parser.py
@@ -6,7 +6,7 @@ the `responses.create` flavours).
 
 import re
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 # --------------------------------------------------------------------------- #
@@ -79,4 +79,44 @@ def extract_usage(obj: Any) -> Dict[str, int]:
         "prompt_tokens": int(prompt_tokens),
         "completion_tokens": int(completion_tokens),
         "cached_tokens": int(cached_tokens),
+    }
+
+
+def _get_nested_int(data: Dict[str, Any], *keys: str) -> int:
+    current: Any = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return 0
+        current = current.get(key)
+    return int(current or 0)
+
+
+def extract_usage_from_payload(payload: Dict[str, Any]) -> Optional[Dict[str, int]]:
+    """
+    Extract usage from a raw OpenAI-compatible JSON response payload.
+
+    Supports both Chat Completions and Responses API usage schemas. Returns
+    None when the payload has no top-level ``usage`` object.
+    """
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    if "input_tokens" in usage or "output_tokens" in usage:
+        prompt_tokens = _get_nested_int(usage, "input_tokens")
+        completion_tokens = _get_nested_int(usage, "output_tokens")
+        cached_tokens = _get_nested_int(
+            usage, "input_tokens_details", "cached_tokens"
+        )
+    else:
+        prompt_tokens = _get_nested_int(usage, "prompt_tokens")
+        completion_tokens = _get_nested_int(usage, "completion_tokens")
+        cached_tokens = _get_nested_int(
+            usage, "prompt_tokens_details", "cached_tokens"
+        )
+
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cached_tokens": cached_tokens,
     }

--- a/openai_cost_calculator/proxy/__init__.py
+++ b/openai_cost_calculator/proxy/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from .app import app, create_app
+from .registry import TrackerRegistry
+
+__all__ = ["TrackerRegistry", "app", "create_app"]

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, Optional
+
+import httpx
+
+try:
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse, Response, StreamingResponse
+except ImportError as exc:  # pragma: no cover - exercised when optional deps are absent
+    raise ImportError(
+        "The proxy requires optional web dependencies. Install with "
+        "`pip install openai-cost-calculator[proxy]`."
+    ) from exc
+
+from openai_cost_calculator.parser import extract_usage_from_payload
+from openai_cost_calculator.proxy.registry import TrackerRegistry, default_registry
+
+
+_HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def create_app(
+    *,
+    upstream: str = "https://api.openai.com/v1",
+    registry: Optional[TrackerRegistry] = None,
+    transport: Optional[httpx.AsyncBaseTransport] = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.state.occ_upstream = upstream.rstrip("/")
+    app.state.occ_registry = registry or default_registry
+    app.state.occ_transport = transport
+
+    @app.get("/_occ/costs")
+    async def costs() -> JSONResponse:
+        return JSONResponse(app.state.occ_registry.summary())
+
+    @app.post("/_occ/reset")
+    async def reset() -> JSONResponse:
+        app.state.occ_registry.reset()
+        return JSONResponse({"ok": True})
+
+    @app.get("/_occ/costs/stream")
+    async def cost_stream() -> StreamingResponse:
+        queue = app.state.occ_registry.subscribe()
+
+        async def events() -> AsyncIterator[bytes]:
+            try:
+                yield _sse_data(app.state.occ_registry.summary())
+                while True:
+                    summary = await queue.get()
+                    yield _sse_data(summary)
+            finally:
+                app.state.occ_registry.unsubscribe(queue)
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    @app.api_route("/v1/{path:path}", methods=["GET", "POST"])
+    async def forward(path: str, request: Request) -> Response:
+        body = await request.body()
+        session_id = request.headers.get("x-occ-session")
+        turn_label = request.headers.get("x-occ-turn")
+        request_payload = _json_from_bytes(body)
+
+        if request.method == "POST" and request_payload.get("stream") is True:
+            return await _forward_streaming(
+                app,
+                path,
+                request,
+                body,
+                session_id=session_id,
+                turn_label=turn_label,
+                request_payload=request_payload,
+            )
+
+        return await _forward_buffered(
+            app,
+            path,
+            request,
+            body,
+            session_id=session_id,
+            turn_label=turn_label,
+        )
+
+    return app
+
+
+async def _forward_buffered(
+    app: FastAPI,
+    path: str,
+    request: Request,
+    body: bytes,
+    *,
+    session_id: Optional[str],
+    turn_label: Optional[str],
+) -> Response:
+    async with _client(app) as client:
+        upstream_response = await client.request(
+            request.method,
+            _upstream_url(app, path, request),
+            headers=_forward_headers(request),
+            content=body,
+        )
+
+    _record_from_payload(
+        app.state.occ_registry,
+        session_id,
+        turn_label,
+        upstream_response.status_code,
+        upstream_response.headers.get("content-type"),
+        upstream_response.content,
+    )
+
+    return Response(
+        content=upstream_response.content,
+        status_code=upstream_response.status_code,
+        headers=_response_headers(upstream_response.headers),
+    )
+
+
+async def _forward_streaming(
+    app: FastAPI,
+    path: str,
+    request: Request,
+    body: bytes,
+    *,
+    session_id: Optional[str],
+    turn_label: Optional[str],
+    request_payload: dict,
+) -> StreamingResponse:
+    client = _client(app)
+    upstream_request = client.build_request(
+        request.method,
+        _upstream_url(app, path, request),
+        headers=_forward_headers(request),
+        content=body,
+    )
+    upstream_response = await client.send(upstream_request, stream=True)
+    parser = _SSEUsageParser(default_model=request_payload.get("model"))
+
+    async def chunks() -> AsyncIterator[bytes]:
+        completed = False
+        try:
+            async for chunk in upstream_response.aiter_raw():
+                parser.feed(chunk)
+                yield chunk
+            completed = True
+        finally:
+            parser.close()
+            if completed and upstream_response.status_code < 400:
+                usage_payload = parser.usage_payload
+                if usage_payload is not None:
+                    _record_json_payload(
+                        app.state.occ_registry,
+                        session_id,
+                        turn_label,
+                        usage_payload,
+                    )
+            await upstream_response.aclose()
+            await client.aclose()
+
+    return StreamingResponse(
+        chunks(),
+        status_code=upstream_response.status_code,
+        headers=_response_headers(upstream_response.headers, streaming=True),
+    )
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        timeout=None,
+        transport=app.state.occ_transport,
+    )
+
+
+def _upstream_url(app: FastAPI, path: str, request: Request) -> str:
+    url = f"{app.state.occ_upstream}/{path}"
+    if request.url.query:
+        url = f"{url}?{request.url.query}"
+    return url
+
+
+def _forward_headers(request: Request) -> list[tuple[bytes, bytes]]:
+    return [
+        (name, value)
+        for name, value in request.headers.raw
+        if name.lower() not in {b"host", b"content-length"}
+    ]
+
+
+def _response_headers(
+    headers: httpx.Headers,
+    *,
+    streaming: bool = False,
+) -> dict[str, str]:
+    excluded = set(_HOP_BY_HOP_HEADERS)
+    if streaming:
+        excluded.add("content-length")
+    return {
+        name: value
+        for name, value in headers.items()
+        if name.lower() not in excluded
+    }
+
+
+def _json_from_bytes(body: bytes) -> dict:
+    if not body:
+        return {}
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _record_from_payload(
+    registry: TrackerRegistry,
+    session_id: Optional[str],
+    turn_label: Optional[str],
+    status_code: int,
+    content_type: Optional[str],
+    content: bytes,
+) -> None:
+    if status_code >= 400:
+        return
+    if content_type is not None and "json" not in content_type.lower():
+        return
+    payload = _json_from_bytes(content)
+    _record_json_payload(registry, session_id, turn_label, payload)
+
+
+def _record_json_payload(
+    registry: TrackerRegistry,
+    session_id: Optional[str],
+    turn_label: Optional[str],
+    payload: dict,
+) -> None:
+    usage = extract_usage_from_payload(payload)
+    model = payload.get("model")
+    if usage is None or not isinstance(model, str):
+        return
+    registry.record_call(session_id, model, usage, turn_label=turn_label)
+
+
+def _sse_data(payload: dict) -> bytes:
+    return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode("utf-8")
+
+
+class _SSEUsageParser:
+    def __init__(self, *, default_model: Any = None) -> None:
+        self._buffer = ""
+        self._default_model = default_model
+        self.usage_payload: Optional[dict] = None
+
+    def feed(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        self._buffer += chunk.decode("utf-8", errors="ignore")
+        while True:
+            event, separator = self._pop_event()
+            if separator is None:
+                return
+            self._handle_event(event)
+
+    def close(self) -> None:
+        if self._buffer.strip():
+            self._handle_event(self._buffer)
+        self._buffer = ""
+
+    def _pop_event(self) -> tuple[str, Optional[str]]:
+        indexes = [
+            index
+            for index in (
+                self._buffer.find("\n\n"),
+                self._buffer.find("\r\n\r\n"),
+            )
+            if index != -1
+        ]
+        if not indexes:
+            return "", None
+        index = min(indexes)
+        separator = "\r\n\r\n" if self._buffer.startswith("\r\n\r\n", index) else "\n\n"
+        event = self._buffer[:index]
+        self._buffer = self._buffer[index + len(separator) :]
+        return event, separator
+
+    def _handle_event(self, event: str) -> None:
+        data_lines = []
+        for line in event.splitlines():
+            if line.startswith("data:"):
+                data_lines.append(line[5:].lstrip())
+        if not data_lines:
+            return
+        raw_data = "\n".join(data_lines)
+        if raw_data == "[DONE]":
+            return
+        payload = _json_from_bytes(raw_data.encode("utf-8"))
+        if not payload or extract_usage_from_payload(payload) is None:
+            return
+        if "model" not in payload and isinstance(self._default_model, str):
+            payload = {**payload, "model": self._default_model}
+        self.usage_payload = payload
+
+
+app = create_app()

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from threading import RLock
+from typing import Dict, Optional
+
+from openai_cost_calculator.tracker import CallRecord, CostTracker
+
+
+class TrackerRegistry:
+    def __init__(self, on_error=None) -> None:
+        self._trackers: Dict[str, CostTracker] = {}
+        self._subscribers: list[asyncio.Queue] = []
+        self._lock = RLock()
+        self._on_error = on_error
+
+    def get(self, session_id: Optional[str]) -> CostTracker:
+        key = session_id or "default"
+        with self._lock:
+            tracker = self._trackers.get(key)
+            if tracker is None:
+                tracker = CostTracker(on_error=self._on_error)
+                self._trackers[key] = tracker
+            return tracker
+
+    def record_call(
+        self,
+        session_id: Optional[str],
+        model: str,
+        usage: dict,
+        *,
+        turn_label: Optional[str] = None,
+    ) -> Optional[CallRecord]:
+        key = session_id or "default"
+        tracker = self.get(key)
+        record = tracker.record_call(
+            model,
+            usage,
+            turn_label=turn_label,
+        )
+        if record is not None:
+            self.notify()
+        elif tracker.session_total == Decimal("0") and not tracker.turns:
+            with self._lock:
+                if self._trackers.get(key) is tracker:
+                    del self._trackers[key]
+        return record
+
+    def reset(self) -> None:
+        with self._lock:
+            self._trackers.clear()
+        self.notify()
+
+    def subscribe(self) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue()
+        with self._lock:
+            self._subscribers.append(queue)
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue) -> None:
+        with self._lock:
+            if queue in self._subscribers:
+                self._subscribers.remove(queue)
+
+    def notify(self) -> None:
+        summary = self.summary()
+        with self._lock:
+            subscribers = list(self._subscribers)
+        for queue in subscribers:
+            queue.put_nowait(summary)
+
+    def summary(self) -> dict:
+        with self._lock:
+            trackers = dict(self._trackers)
+
+        sessions = {}
+        grand_total = Decimal("0")
+        for session_id, tracker in trackers.items():
+            grand_total += tracker.session_total
+            sessions[session_id] = {
+                "session_total": f"{tracker.session_total:.8f}",
+                "turns": [turn.as_dict() for turn in tracker.turns],
+            }
+
+        return {
+            "sessions": sessions,
+            "grand_total": f"{grand_total:.8f}",
+        }
+
+
+default_registry = TrackerRegistry()

--- a/openai_cost_calculator/tracker.py
+++ b/openai_cost_calculator/tracker.py
@@ -6,8 +6,9 @@ from decimal import Decimal
 import time
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
-from .estimate import estimate_cost_typed
-from .parser import extract_usage
+from .core import calculate_cost_typed
+from .estimate import _find_rates, estimate_cost_typed
+from .parser import extract_model_details, extract_usage
 from .types import CostBreakdown
 
 
@@ -187,6 +188,20 @@ class CostTracker:
         self.session_total += record.cost.total_cost
         return record
 
+    def record_call(
+        self,
+        model: str,
+        usage: dict,
+        *,
+        turn_label: Optional[str] = None,
+    ) -> Optional[CallRecord]:
+        try:
+            return self._record_call(model, usage, turn_label=turn_label)
+        except Exception as exc:
+            if self.on_error is not None:
+                self.on_error(exc)
+            return None
+
     def wrap(self, client: Any) -> Any:
         chat_completions = getattr(getattr(client, "chat", None), "completions", None)
         if chat_completions is not None:
@@ -202,6 +217,41 @@ class CostTracker:
         self.turns.clear()
         self.session_total = Decimal("0")
         self._active_turn = None
+
+    def _find_or_create_turn(self, label: Optional[str]) -> Turn:
+        for turn in self.turns:
+            if turn.label == label:
+                return turn
+        turn = Turn(label)
+        self.turns.append(turn)
+        return turn
+
+    def _record_call(
+        self,
+        model: str,
+        usage: dict,
+        *,
+        turn_label: Optional[str] = None,
+    ) -> CallRecord:
+        details = extract_model_details(model)
+        rates = _find_rates(
+            details["model_name"],
+            details["model_date"],
+            usage["prompt_tokens"],
+        )
+        cost = calculate_cost_typed(usage, rates)
+        record = CallRecord(
+            model=model,
+            prompt_tokens=usage["prompt_tokens"],
+            completion_tokens=usage["completion_tokens"],
+            cached_tokens=usage["cached_tokens"],
+            cost=cost,
+            timestamp=time.time(),
+        )
+        turn = self._active_turn or self._find_or_create_turn(turn_label)
+        turn.add(record)
+        self.session_total += record.cost.total_cost
+        return record
 
     def _wrap_create(self, owner: Any) -> None:
         original = getattr(owner, "create", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,23 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
+dependencies = [
+    "requests",
+]
 
-[tool.setuptools]
-packages = ["openai_cost_calculator"]
+[project.optional-dependencies]
+proxy = [
+    "fastapi",
+    "httpx",
+    "uvicorn",
+]
+
+[project.scripts]
+openai-cost-calculator = "openai_cost_calculator.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["openai_cost_calculator*"]
 
 [project.urls]
 Homepage = "https://github.com/orkunkinay/openai_cost_calculator"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
 pytest==8.3.5
 requests
+fastapi
+httpx

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,18 @@ setup(
         "openai_cost_calculator": ["data/gpt_pricing_data.csv"],
     },
     install_requires=["requests"],
+    extras_require={
+        "proxy": ["fastapi", "httpx", "uvicorn"],
+    },
+    entry_points={
+        "console_scripts": [
+            "openai-cost-calculator=openai_cost_calculator.cli:main",
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.9',
 )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from openai_cost_calculator.parser import extract_usage_from_payload
+from openai_cost_calculator.pricing import (
+    add_pricing_entry,
+    clear_local_pricing,
+    set_offline_mode,
+)
+from openai_cost_calculator.proxy.app import create_app
+from openai_cost_calculator.proxy.registry import TrackerRegistry
+
+
+class AsyncChunkStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self.chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk
+
+
+@pytest.fixture(autouse=True)
+def pinned_pricing():
+    clear_local_pricing()
+    set_offline_mode(True)
+    add_pricing_entry(
+        "gpt-test",
+        "2025-01-01",
+        input_price=1.0,
+        output_price=2.0,
+        cached_input_price=0.5,
+    )
+    yield
+    clear_local_pricing()
+    set_offline_mode(False)
+
+
+def _client(handler):
+    transport = httpx.MockTransport(handler)
+    app = create_app(
+        upstream="https://upstream.example/v1",
+        transport=transport,
+        registry=TrackerRegistry(),
+    )
+    return TestClient(app)
+
+
+def test_extract_usage_from_payload_supports_chat_and_responses_shapes():
+    chat = {
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "prompt_tokens_details": {"cached_tokens": 25},
+        }
+    }
+    responses = {
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "input_tokens_details": {"cached_tokens": 25},
+        }
+    }
+
+    expected = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "cached_tokens": 25,
+    }
+    assert extract_usage_from_payload(chat) == expected
+    assert extract_usage_from_payload(responses) == expected
+    assert extract_usage_from_payload({"id": "no-usage"}) is None
+
+
+def test_non_streaming_post_returns_body_unchanged_and_records_session_cost():
+    upstream_body = json.dumps(
+        {
+            "id": "chatcmpl-test",
+            "model": "gpt-test-2025-01-01",
+            "usage": {
+                "prompt_tokens": 1_000,
+                "completion_tokens": 2_000,
+                "prompt_tokens_details": {"cached_tokens": 100},
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert str(request.url) == "https://upstream.example/v1/chat/completions?beta=1"
+        assert request.headers["authorization"] == "Bearer test-token"
+        assert await request.aread() == b'{"model":"gpt-test-2025-01-01"}'
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=upstream_body,
+        )
+
+    client = _client(handler)
+    response = client.post(
+        "/v1/chat/completions?beta=1",
+        content=b'{"model":"gpt-test-2025-01-01"}',
+        headers={
+            "authorization": "Bearer test-token",
+            "x-occ-session": "agent-a",
+        },
+    )
+
+    assert response.content == upstream_body
+    costs = client.get("/_occ/costs").json()
+    assert costs["grand_total"] == "0.00495000"
+    assert costs["sessions"]["agent-a"]["session_total"] == "0.00495000"
+
+
+def test_streaming_sse_passes_body_through_and_costs_final_usage_event():
+    chunks = [
+        b'data: {"id":"chunk-1","model":"gpt-test-2025-01-01"}\n\n',
+        (
+            b'data: {"id":"chunk-2","model":"gpt-test-2025-01-01",'
+            b'"usage":{"prompt_tokens":2000,"completion_tokens":3000,'
+            b'"prompt_tokens_details":{"cached_tokens":500}}}\n\n'
+        ),
+        b"data: [DONE]\n\n",
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads((await request.aread()).decode("utf-8"))["stream"] is True
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=AsyncChunkStream(chunks),
+        )
+
+    client = _client(handler)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-test-2025-01-01",
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        },
+        headers={"x-occ-session": "stream-session"},
+    )
+
+    assert response.content == b"".join(chunks)
+    costs = client.get("/_occ/costs").json()
+    assert costs["sessions"]["stream-session"]["session_total"] == "0.00775000"
+
+
+def test_costs_endpoint_reflects_turn_grouping():
+    calls = [
+        {
+            "model": "gpt-test-2025-01-01",
+            "usage": {"prompt_tokens": 1_000, "completion_tokens": 0},
+        },
+        {
+            "model": "gpt-test-2025-01-01",
+            "usage": {"prompt_tokens": 0, "completion_tokens": 1_000},
+        },
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json=calls.pop(0),
+        )
+
+    client = _client(handler)
+    for _ in range(2):
+        client.post(
+            "/v1/responses",
+            json={"model": "gpt-test-2025-01-01"},
+            headers={"x-occ-session": "agent-b", "x-occ-turn": "turn-1"},
+        )
+
+    costs = client.get("/_occ/costs").json()
+    turn = costs["sessions"]["agent-b"]["turns"][0]
+    assert turn["label"] == "turn-1"
+    assert turn["num_calls"] == 2
+    assert turn["prompt_tokens"] == 1_000
+    assert turn["completion_tokens"] == 1_000
+    assert costs["sessions"]["agent-b"]["session_total"] == "0.00300000"
+
+
+def test_upstream_error_and_missing_usage_record_nothing():
+    responses = [
+        httpx.Response(
+            500,
+            headers={"content-type": "application/json"},
+            json={"model": "gpt-test-2025-01-01", "usage": {"prompt_tokens": 100}},
+        ),
+        httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            json={"model": "gpt-test-2025-01-01"},
+        ),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    client = _client(handler)
+    assert client.post("/v1/chat/completions").status_code == 500
+    assert client.post("/v1/chat/completions").status_code == 200
+    assert client.get("/_occ/costs").json() == {
+        "sessions": {},
+        "grand_total": "0.00000000",
+    }
+
+
+def test_costing_failure_is_swallowed_and_response_is_unchanged():
+    upstream_body = b'{"model":"unknown-2099-01-01","usage":{"prompt_tokens":1}}'
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            content=upstream_body,
+        )
+
+    client = _client(handler)
+    response = client.post("/v1/chat/completions", headers={"x-occ-session": "bad"})
+
+    assert response.content == upstream_body
+    assert client.get("/_occ/costs").json() == {
+        "sessions": {},
+        "grand_total": "0.00000000",
+    }


### PR DESCRIPTION
Adds an optional FastAPI reverse proxy that forwards OpenAI-compatible requests while tracking per-session and per-turn costs from raw JSON and SSE usage payloads.
Extends CostTracker with a JSON-native record_call path and adds a CLI proxy subcommand plus optional proxy dependencies.
Documents zero-config proxy usage and grouping headers in the README.
Validated with the full offline pytest suite: 41 passed.
