### PR TITLE
[codex] Add agent UI cost adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,61 @@ costed.
 
 ---
 
+## Show cost inside Claude Code & Codex
+
+Install the Claude Code UI adapters:
+
+```bash
+openai-cost-calculator install claude-code
+```
+
+This adds a Claude Code status line command and a `Stop` hook. The status line
+shows the running Claude Code session cost, and the hook prints an inline
+per-turn line after each assistant response:
+
+```text
+💰 $0.0123 session · last 8.5k->1.2k tok (cache 2.0k) · Sonnet 4.6 · ctx 14%
+💰 This turn cost $0.0041 (12.3k in / 1.1k out)
+```
+
+Claude Code session totals come from Claude Code's own status-line JSON. The
+per-turn hook prefers exact per-message costs from the local transcript; if only
+usage is available, it estimates from seeded Claude prices.
+
+Install the Codex adapters:
+
+```bash
+openai-cost-calculator install codex --proxy-url http://127.0.0.1:8100 --session default
+```
+
+Run the proxy and route Codex's OpenAI-compatible provider through it:
+
+```bash
+openai-cost-calculator proxy --port 8100
+```
+
+Codex notifications use the proxy checkpoint endpoint, so one
+`agent-turn-complete` notification corresponds to one cost checkpoint:
+
+```text
+💰 $0.0188 session · last $0.0032
+💰 Turn $0.0032 · gpt-5.5 1.2k->500
+```
+
+Codex does not pass token or cost data to `notify`; these numbers come from the
+local proxy. Current Codex docs expose `notify` as an external program and the
+TUI status line as built-in footer items, so `occ-codex-statusline` is provided
+for wrappers or future Codex builds that can run an external status command.
+
+Undo either install with:
+
+```bash
+openai-cost-calculator uninstall claude-code
+openai-cost-calculator uninstall codex
+```
+
+---
+
 ## Highlights
 
 - **Typed API:** `CostBreakdown` dataclass with `Decimal` precision  

--- a/openai_cost_calculator/__init__.py
+++ b/openai_cost_calculator/__init__.py
@@ -38,6 +38,7 @@ from .pricing import (
 )
 from .types import CostBreakdown
 from .tracker import CostTracker, Turn, CallRecord
+from .adapters.anthropic_pricing import seed_anthropic_pricing
 
 __all__ = [
     "estimate_cost", 
@@ -53,4 +54,5 @@ __all__ = [
     "CostTracker",
     "Turn",
     "CallRecord",
+    "seed_anthropic_pricing",
 ]

--- a/openai_cost_calculator/adapters/__init__.py
+++ b/openai_cost_calculator/adapters/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/openai_cost_calculator/adapters/anthropic_pricing.py
+++ b/openai_cost_calculator/adapters/anthropic_pricing.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from openai_cost_calculator.pricing import add_pricing_entries
+
+
+# Prices are USD per 1M tokens. Prompt cache writes are intentionally not
+# represented: the core calculator has uncached input, cached input/read, and
+# output buckets. Prefer Claude transcript-supplied per-message costs when
+# available; these rows are only a fallback for usage-only transcripts.
+_ANTHROPIC_PRICES = [
+    ("claude-fable-5", "2026-06-20", 10.0, 50.0, 1.0),
+    ("claude-mythos-5", "2026-06-20", 10.0, 50.0, 1.0),
+    ("claude-opus-4-8", "2026-06-20", 5.0, 25.0, 0.5),
+    ("claude-opus-4-7", "2026-06-20", 5.0, 25.0, 0.5),
+    ("claude-opus-4-6", "2026-06-20", 5.0, 25.0, 0.5),
+    ("claude-opus-4-5", "2026-06-20", 5.0, 25.0, 0.5),
+    ("claude-opus-4-1", "2026-06-20", 15.0, 75.0, 1.5),
+    ("claude-opus-4", "2026-06-20", 15.0, 75.0, 1.5),
+    ("claude-sonnet-4-6", "2026-06-20", 3.0, 15.0, 0.3),
+    ("claude-sonnet-4-5", "2026-06-20", 3.0, 15.0, 0.3),
+    ("claude-sonnet-4", "2026-06-20", 3.0, 15.0, 0.3),
+    ("claude-haiku-4-5", "2026-06-20", 1.0, 5.0, 0.1),
+]
+
+
+def seed_anthropic_pricing() -> None:
+    add_pricing_entries(_ANTHROPIC_PRICES, replace=True)
+

--- a/openai_cost_calculator/adapters/claude_code.py
+++ b/openai_cost_calculator/adapters/claude_code.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from openai_cost_calculator.adapters.anthropic_pricing import seed_anthropic_pricing
+from openai_cost_calculator.adapters.common import (
+    MONEY,
+    SEP,
+    compact_tokens,
+    decimal_from,
+    format_money,
+    int_from,
+    nested,
+)
+from openai_cost_calculator.core import calculate_cost_typed
+from openai_cost_calculator.estimate import _find_rates
+from openai_cost_calculator.parser import extract_model_details
+
+
+@dataclass
+class _AssistantCost:
+    cost: Decimal
+    prompt_tokens: int
+    completion_tokens: int
+    cached_tokens: int
+
+
+def statusline_text(payload: dict[str, Any]) -> str:
+    cost = decimal_from(nested(payload, "cost", "total_cost_usd"))
+    model = (
+        nested(payload, "model", "display_name")
+        or nested(payload, "model", "id")
+        or "model"
+    )
+    context = payload.get("context_window") if isinstance(payload, dict) else {}
+    context = context if isinstance(context, dict) else {}
+
+    current_usage = context.get("current_usage")
+    if isinstance(current_usage, dict):
+        input_tokens = int_from(current_usage.get("input_tokens"))
+        output_tokens = int_from(current_usage.get("output_tokens"))
+        cached_tokens = int_from(current_usage.get("cache_read_input_tokens")) + int_from(
+            current_usage.get("cache_creation_input_tokens")
+        )
+        last = (
+            f"last {compact_tokens(input_tokens)}->{compact_tokens(output_tokens)} tok"
+        )
+        if cached_tokens:
+            last = f"{last} (cache {compact_tokens(cached_tokens)})"
+    else:
+        last = "last -- tok"
+
+    ctx_pct = _context_percent(context)
+    ctx = f"ctx {ctx_pct}%" if ctx_pct is not None else "ctx --"
+    return (
+        f"{MONEY} {format_money(cost)} session {SEP} {last} "
+        f"{SEP} {model} {SEP} {ctx}"
+    )
+
+
+def statusline_main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+        if not isinstance(payload, dict):
+            payload = {}
+        print(statusline_text(payload))
+    except Exception:
+        print(f"{MONEY} $0.0000 session {SEP} ctx --")
+    return 0
+
+
+def stop_hook_output(
+    payload: dict[str, Any],
+    *,
+    cache_dir: Optional[Path] = None,
+) -> dict[str, str]:
+    session_id = str(payload.get("session_id") or "default")
+    transcript_path = payload.get("transcript_path")
+    if not isinstance(transcript_path, str) or not transcript_path:
+        return {}
+
+    records = _read_jsonl(Path(os.path.expanduser(transcript_path)))
+    if not records:
+        return {}
+
+    cache_path = _cache_path(session_id, transcript_path, cache_dir)
+    last_index = _read_cache_index(cache_path)
+    start_index = _turn_start_index(records, last_index)
+    selected = [
+        (index, record)
+        for index, record in enumerate(records)
+        if index >= start_index and _role(record) == "assistant"
+    ]
+    if not selected:
+        _write_cache_index(cache_path, len(records))
+        return {}
+
+    total = _sum_assistant_costs((record for _, record in selected), payload)
+    _write_cache_index(cache_path, len(records))
+    if total is None or total.cost <= 0:
+        return {}
+
+    message = (
+        f"{MONEY} This turn cost {format_money(total.cost)} "
+        f"({compact_tokens(total.prompt_tokens)} in / "
+        f"{compact_tokens(total.completion_tokens)} out)"
+    )
+    return {"systemMessage": message}
+
+
+def stop_hook_main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read() or "{}")
+        if not isinstance(payload, dict):
+            payload = {}
+        output = stop_hook_output(payload)
+    except Exception:
+        output = {}
+    print(json.dumps(output, separators=(",", ":")))
+    return 0
+
+
+def _context_percent(context: dict[str, Any]) -> Optional[int]:
+    size = int_from(context.get("context_window_size"))
+    total = int_from(context.get("total_input_tokens"))
+    if size > 0 and total >= 0:
+        return int((Decimal(total) / Decimal(size) * Decimal("100")).quantize(Decimal("1")))
+    used = context.get("used_percentage")
+    if used is not None:
+        return int(decimal_from(used).quantize(Decimal("1")))
+    return None
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    value = json.loads(line)
+                except Exception:
+                    continue
+                if isinstance(value, dict):
+                    records.append(value)
+    except Exception:
+        return []
+    return records
+
+
+def _cache_path(
+    session_id: str,
+    transcript_path: str,
+    cache_dir: Optional[Path],
+) -> Path:
+    root = cache_dir or Path(
+        os.environ.get("OCC_CACHE_DIR")
+        or os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache")
+    ) / "occ"
+    digest = hashlib.sha256(f"{session_id}:{transcript_path}".encode("utf-8")).hexdigest()
+    return root / f"claude-{digest[:24]}.json"
+
+
+def _read_cache_index(path: Path) -> Optional[int]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if isinstance(payload, dict) and isinstance(payload.get("last_index"), int):
+        return int(payload["last_index"])
+    return None
+
+
+def _write_cache_index(path: Path, index: int) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"last_index": index}), encoding="utf-8")
+    except Exception:
+        return
+
+
+def _turn_start_index(records: list[dict[str, Any]], last_index: Optional[int]) -> int:
+    if last_index is not None:
+        return min(max(last_index, 0), len(records))
+    last_assistant = max(
+        (index for index, record in enumerate(records) if _role(record) == "assistant"),
+        default=-1,
+    )
+    if last_assistant == -1:
+        return len(records)
+    for index in range(last_assistant - 1, -1, -1):
+        if _role(records[index]) == "user":
+            return index + 1
+    return 0
+
+
+def _role(record: dict[str, Any]) -> Optional[str]:
+    for value in (
+        nested(record, "message", "role"),
+        record.get("role"),
+        record.get("type"),
+    ):
+        if value in {"assistant", "user"}:
+            return str(value)
+    return None
+
+
+def _sum_assistant_costs(
+    records: Iterable[dict[str, Any]],
+    hook_payload: dict[str, Any],
+) -> Optional[_AssistantCost]:
+    total = _AssistantCost(Decimal("0"), 0, 0, 0)
+    usage_records: list[tuple[str, dict[str, int]]] = []
+
+    for record in records:
+        cost = _message_cost(record)
+        usage = _message_usage(record)
+        if usage is not None:
+            total.prompt_tokens += usage["prompt_tokens"]
+            total.completion_tokens += usage["completion_tokens"]
+            total.cached_tokens += usage["cached_tokens"]
+        if cost is not None:
+            total.cost += cost
+        elif usage is not None:
+            model = _message_model(record) or nested(hook_payload, "model", "id")
+            if isinstance(model, str) and model:
+                usage_records.append((model, usage))
+
+    if total.cost == 0 and usage_records:
+        seed_anthropic_pricing()
+        for model, usage in usage_records:
+            try:
+                details = extract_model_details(model)
+                rates = _find_rates(
+                    details["model_name"],
+                    details["model_date"],
+                    usage["prompt_tokens"],
+                )
+                total.cost += calculate_cost_typed(usage, rates).total_cost
+            except Exception:
+                continue
+
+    if total.cost == 0 and total.prompt_tokens == 0 and total.completion_tokens == 0:
+        return None
+    return total
+
+
+def _message_cost(record: dict[str, Any]) -> Optional[Decimal]:
+    candidates = (
+        record.get("cost_usd"),
+        record.get("total_cost_usd"),
+        nested(record, "cost", "total_cost_usd"),
+        nested(record, "message", "cost_usd"),
+        nested(record, "message", "total_cost_usd"),
+        nested(record, "message", "cost", "total_cost_usd"),
+        nested(record, "message", "usage", "cost_usd"),
+    )
+    for candidate in candidates:
+        if candidate is not None:
+            cost = decimal_from(candidate)
+            if cost > 0:
+                return cost
+    return None
+
+
+def _message_usage(record: dict[str, Any]) -> Optional[dict[str, int]]:
+    usage = record.get("usage")
+    if not isinstance(usage, dict):
+        usage = nested(record, "message", "usage")
+    if not isinstance(usage, dict):
+        return None
+
+    input_tokens = int_from(usage.get("input_tokens") or usage.get("prompt_tokens"))
+    output_tokens = int_from(usage.get("output_tokens") or usage.get("completion_tokens"))
+    cache_read = int_from(usage.get("cache_read_input_tokens"))
+    cache_write = int_from(usage.get("cache_creation_input_tokens"))
+    cached_tokens = int_from(
+        nested(usage, "input_tokens_details", "cached_tokens")
+        or nested(usage, "prompt_tokens_details", "cached_tokens")
+        or cache_read
+    )
+    prompt_tokens = input_tokens + cache_write
+    if prompt_tokens == 0 and output_tokens == 0 and cached_tokens == 0:
+        return None
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": output_tokens,
+        "cached_tokens": cached_tokens,
+    }
+
+
+def _message_model(record: dict[str, Any]) -> Optional[str]:
+    for candidate in (
+        record.get("model"),
+        nested(record, "message", "model"),
+        nested(record, "message", "model", "id"),
+    ):
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+

--- a/openai_cost_calculator/adapters/codex.py
+++ b/openai_cost_calculator/adapters/codex.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from decimal import Decimal
+from typing import Any, Optional
+
+from openai_cost_calculator.adapters.common import (
+    MONEY,
+    SEP,
+    compact_tokens,
+    decimal_from,
+    format_money,
+)
+
+
+def checkpoint_text(
+    payload: dict[str, Any],
+    *,
+    proxy_url: Optional[str] = None,
+    session: Optional[str] = None,
+) -> Optional[str]:
+    session_id = session or os.environ.get("OCC_SESSION") or "default"
+    data = _post_json(
+        _url(proxy_url, "/_occ/checkpoint", {"session": session_id}),
+        timeout=1.0,
+    )
+    if not data:
+        return None
+    cost = decimal_from(data.get("total_cost"))
+    if cost <= 0:
+        return None
+    model = _primary_model(data)
+    prompt_tokens = int(data.get("prompt_tokens") or 0)
+    completion_tokens = int(data.get("completion_tokens") or 0)
+    return (
+        f"{MONEY} Turn {format_money(cost)} {SEP} "
+        f"{model} {compact_tokens(prompt_tokens)}->{compact_tokens(completion_tokens)}"
+    )
+
+
+def notify_main() -> int:
+    try:
+        notification = json.loads(sys.argv[1]) if len(sys.argv) > 1 else {}
+        if not isinstance(notification, dict):
+            return 0
+        if notification.get("type") != "agent-turn-complete":
+            return 0
+        session = os.environ.get("OCC_SESSION") or notification.get("thread-id")
+        line = checkpoint_text(notification, session=session)
+        if line:
+            print(line)
+    except Exception:
+        return 0
+    return 0
+
+
+def statusline_text(
+    *,
+    proxy_url: Optional[str] = None,
+    session: Optional[str] = None,
+) -> str:
+    session_id = session or os.environ.get("OCC_SESSION") or "default"
+    try:
+        data = _get_json(
+            _url(proxy_url, "/_occ/costs", {"session": session_id}),
+            timeout=1.0,
+        )
+        if data is None:
+            return f"{MONEY} cost offline"
+        session_data = _session_data(data, session_id)
+        if not session_data:
+            return f"{MONEY} $0.0000 session {SEP} last $0.0000"
+        total = decimal_from(session_data.get("session_total"))
+        turns = session_data.get("turns")
+        last_cost = Decimal("0")
+        if isinstance(turns, list) and turns:
+            last = turns[-1]
+            if isinstance(last, dict):
+                last_cost = decimal_from(last.get("total_cost"))
+        return (
+            f"{MONEY} {format_money(total)} session {SEP} "
+            f"last {format_money(last_cost)}"
+        )
+    except Exception:
+        return f"{MONEY} cost offline"
+
+
+def statusline_main() -> int:
+    print(statusline_text())
+    return 0
+
+
+def _url(
+    proxy_url: Optional[str],
+    path: str,
+    query: Optional[dict[str, str]] = None,
+) -> str:
+    base = (proxy_url or os.environ.get("OCC_PROXY_URL") or "http://127.0.0.1:8100").rstrip("/")
+    url = f"{base}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    return url
+
+
+def _get_json(url: str, *, timeout: float) -> Optional[dict[str, Any]]:
+    request = urllib.request.Request(url, method="GET")
+    return _read_json(request, timeout=timeout)
+
+
+def _post_json(url: str, *, timeout: float) -> Optional[dict[str, Any]]:
+    request = urllib.request.Request(url, method="POST")
+    return _read_json(request, timeout=timeout)
+
+
+def _read_json(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+) -> Optional[dict[str, Any]]:
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _primary_model(data: dict[str, Any]) -> str:
+    models = data.get("models")
+    if isinstance(models, dict) and models:
+        def model_cost(item: tuple[str, Any]) -> Decimal:
+            value = item[1]
+            if isinstance(value, dict):
+                return decimal_from(value.get("total_cost"))
+            return Decimal("0")
+
+        return max(models.items(), key=model_cost)[0]
+    costs = data.get("cost_by_model")
+    if isinstance(costs, dict) and costs:
+        return max(costs.items(), key=lambda item: decimal_from(item[1]))[0]
+    return "model"
+
+
+def _session_data(
+    data: Optional[dict[str, Any]],
+    session_id: str,
+) -> Optional[dict[str, Any]]:
+    if not data:
+        return None
+    if "session_total" in data:
+        return data
+    sessions = data.get("sessions")
+    if isinstance(sessions, dict):
+        value = sessions.get(session_id)
+        if isinstance(value, dict):
+            return value
+    return None

--- a/openai_cost_calculator/adapters/common.py
+++ b/openai_cost_calculator/adapters/common.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Optional
+
+
+MONEY = "\U0001f4b0"
+SEP = "\u00b7"
+
+
+def decimal_from(value: Any, default: Decimal = Decimal("0")) -> Decimal:
+    if value is None:
+        return default
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return default
+
+
+def int_from(value: Any, default: int = 0) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return default
+
+
+def compact_tokens(tokens: int) -> str:
+    if abs(tokens) >= 1_000_000:
+        value = Decimal(tokens) / Decimal("1000000")
+        return f"{value:.1f}M"
+    if abs(tokens) >= 1_000:
+        value = Decimal(tokens) / Decimal("1000")
+        return f"{value:.1f}k"
+    return str(tokens)
+
+
+def format_money(value: Decimal, places: str = "0.0001") -> str:
+    return f"${value.quantize(Decimal(places))}"
+
+
+def nested(data: Any, *keys: str) -> Optional[Any]:
+    current = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from pathlib import Path
+from typing import Any, Optional, Tuple
+
+
+OCC_STATUSLINE = {"type": "command", "command": "occ-cc-statusline"}
+OCC_STOP_HOOK = {"type": "command", "command": "occ-cc-stop-hook", "timeout": 5}
+CODEX_BEGIN = "# >>> openai-cost-calculator"
+CODEX_END = "# <<< openai-cost-calculator"
+
+
+def install_claude_code(scope: str = "user") -> list[str]:
+    path = _claude_settings_path(scope)
+    settings = _read_json_object(path)
+    changed: list[str] = []
+
+    if settings.get("statusLine") != OCC_STATUSLINE:
+        settings["statusLine"] = dict(OCC_STATUSLINE)
+        changed.append("statusLine")
+
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        hooks = {}
+        settings["hooks"] = hooks
+        changed.append("hooks")
+    stop_entries = hooks.setdefault("Stop", [])
+    if not isinstance(stop_entries, list):
+        stop_entries = []
+        hooks["Stop"] = stop_entries
+        changed.append("Stop hook")
+    entry = {"matcher": "", "hooks": [dict(OCC_STOP_HOOK)]}
+    if not _has_hook(stop_entries, "occ-cc-stop-hook"):
+        stop_entries.append(entry)
+        changed.append("Stop hook")
+
+    if changed:
+        _backup(path)
+        _write_json(path, settings)
+    return [f"{path}: installed {', '.join(dict.fromkeys(changed))}"] if changed else [f"{path}: already installed"]
+
+
+def uninstall_claude_code(scope: str = "user") -> list[str]:
+    path = _claude_settings_path(scope)
+    settings = _read_json_object(path)
+    changed: list[str] = []
+    if settings.get("statusLine") == OCC_STATUSLINE:
+        del settings["statusLine"]
+        changed.append("statusLine")
+
+    hooks = settings.get("hooks")
+    if isinstance(hooks, dict):
+        stop_entries = hooks.get("Stop")
+        if isinstance(stop_entries, list):
+            filtered = [_remove_hook(entry, "occ-cc-stop-hook") for entry in stop_entries]
+            filtered = [entry for entry in filtered if entry is not None]
+            if filtered != stop_entries:
+                changed.append("Stop hook")
+                if filtered:
+                    hooks["Stop"] = filtered
+                else:
+                    hooks.pop("Stop", None)
+        if not hooks:
+            settings.pop("hooks", None)
+
+    if changed:
+        _backup(path)
+        _write_json(path, settings)
+    return [f"{path}: removed {', '.join(changed)}"] if changed else [f"{path}: not installed"]
+
+
+def install_codex(proxy_url: str, session: str) -> list[str]:
+    path = Path.home() / ".codex" / "config.toml"
+    text = _read_text(path)
+    previous_notify = _managed_previous_notify(text)
+    base = _remove_managed_block(text)
+    extracted_notify, base = _extract_top_level_key(base, "notify")
+    previous_notify = previous_notify or extracted_notify
+    block = _codex_block(proxy_url, session, previous_notify)
+    new_text = _prepend_managed_block(base, block)
+    if new_text != text:
+        _backup(path)
+        _write_text(path, new_text)
+        return [
+            f"{path}: installed notify/statusline adapter block",
+            "Route Codex through the proxy with base_url http://127.0.0.1:8100/v1 and X-OCC-Session if your provider supports static headers.",
+        ]
+    return [f"{path}: already installed"]
+
+
+def uninstall_codex() -> list[str]:
+    path = Path.home() / ".codex" / "config.toml"
+    text = _read_text(path)
+    previous_notify = _managed_previous_notify(text)
+    new_text = _remove_managed_block(text)
+    if previous_notify and _extract_top_level_key(new_text, "notify")[0] is None:
+        new_text = f"{previous_notify}\n{new_text.lstrip()}"
+    if new_text != text:
+        _backup(path)
+        _write_text(path, new_text)
+        return [f"{path}: removed openai-cost-calculator block"]
+    return [f"{path}: not installed"]
+
+
+def _claude_settings_path(scope: str) -> Path:
+    if scope == "project":
+        return Path.cwd() / ".claude" / "settings.json"
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _read_json_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return ""
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _backup(path: Path) -> None:
+    if not path.exists():
+        return
+    stamp = time.strftime("%Y%m%d%H%M%S")
+    backup = path.with_name(f"{path.name}.occ-backup-{stamp}")
+    try:
+        shutil.copy2(path, backup)
+    except Exception:
+        return
+
+
+def _has_hook(entries: list[Any], command: str) -> bool:
+    return any(_entry_has_hook(entry, command) for entry in entries)
+
+
+def _entry_has_hook(entry: Any, command: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    hooks = entry.get("hooks")
+    if not isinstance(hooks, list):
+        return False
+    return any(
+        isinstance(hook, dict) and hook.get("command") == command
+        for hook in hooks
+    )
+
+
+def _remove_hook(entry: Any, command: str) -> Any:
+    if not isinstance(entry, dict):
+        return entry
+    hooks = entry.get("hooks")
+    if not isinstance(hooks, list):
+        return entry
+    filtered = [
+        hook
+        for hook in hooks
+        if not (isinstance(hook, dict) and hook.get("command") == command)
+    ]
+    if not filtered:
+        return None
+    next_entry = dict(entry)
+    next_entry["hooks"] = filtered
+    return next_entry
+
+
+def _codex_block(
+    proxy_url: str,
+    session: str,
+    previous_notify: Optional[str] = None,
+) -> str:
+    escaped_proxy = proxy_url.replace("\\", "\\\\").replace('"', '\\"')
+    escaped_session = session.replace("\\", "\\\\").replace('"', '\\"')
+    previous = f"# previous_notify = {previous_notify}\n" if previous_notify else ""
+    return (
+        f"{CODEX_BEGIN}\n"
+        '# Codex notify is documented as an external program. Current Codex\n'
+        '# docs expose TUI status_line as built-in item identifiers, so the\n'
+        '# statusline command is stored here for wrappers that support it.\n'
+        f"{previous}"
+        'notify = ["occ-codex-notify"]\n'
+        f'occ_codex_proxy_url = "{escaped_proxy}"\n'
+        f'occ_codex_session = "{escaped_session}"\n'
+        'occ_codex_statusline_command = "occ-codex-statusline"\n'
+        f"{CODEX_END}\n"
+    )
+
+
+def _prepend_managed_block(text: str, block: str) -> str:
+    stripped = _remove_managed_block(text).rstrip()
+    if stripped:
+        return f"{block}\n{stripped}\n"
+    return block
+
+
+def _remove_managed_block(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    output: list[str] = []
+    in_block = False
+    for line in lines:
+        if line.strip() == CODEX_BEGIN:
+            in_block = True
+            continue
+        if line.strip() == CODEX_END:
+            in_block = False
+            continue
+        if not in_block:
+            output.append(line)
+    return "".join(output).rstrip() + ("\n" if output else "")
+
+
+def _managed_previous_notify(text: str) -> Optional[str]:
+    in_block = False
+    for line in text.splitlines():
+        if line.strip() == CODEX_BEGIN:
+            in_block = True
+            continue
+        if line.strip() == CODEX_END:
+            return None
+        if in_block and line.startswith("# previous_notify = "):
+            value = line.removeprefix("# previous_notify = ").strip()
+            return value or None
+    return None
+
+
+def _extract_top_level_key(text: str, key: str) -> Tuple[Optional[str], str]:
+    section: Optional[str] = None
+    found: Optional[str] = None
+    output: list[str] = []
+    prefix = f"{key} "
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped
+        if (
+            section is None
+            and found is None
+            and (stripped.startswith(f"{key}=") or stripped.startswith(prefix))
+        ):
+            found = stripped
+            continue
+        output.append(line)
+    return found, "".join(output)

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -13,9 +13,27 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     proxy_parser.add_argument("--port", default=8100, type=int)
     proxy_parser.add_argument("--upstream", default="https://api.openai.com/v1")
 
+    install_parser = subparsers.add_parser("install", help="Install agent UI adapters")
+    install_subparsers = install_parser.add_subparsers(dest="target", required=True)
+    claude_install = install_subparsers.add_parser("claude-code")
+    claude_install.add_argument("--scope", choices=["user", "project"], default="user")
+    codex_install = install_subparsers.add_parser("codex")
+    codex_install.add_argument("--proxy-url", default="http://127.0.0.1:8100")
+    codex_install.add_argument("--session", default="default")
+
+    uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall agent UI adapters")
+    uninstall_subparsers = uninstall_parser.add_subparsers(dest="target", required=True)
+    claude_uninstall = uninstall_subparsers.add_parser("claude-code")
+    claude_uninstall.add_argument("--scope", choices=["user", "project"], default="user")
+    uninstall_subparsers.add_parser("codex")
+
     args = parser.parse_args(argv)
     if args.command == "proxy":
         return _run_proxy(args.host, args.port, args.upstream)
+    if args.command == "install":
+        return _install(args)
+    if args.command == "uninstall":
+        return _uninstall(args)
 
     parser.error(f"unknown command: {args.command}")
     return 2
@@ -37,6 +55,41 @@ def _run_proxy(host: str, port: int, upstream: str) -> int:
     print(f"OpenAI-compatible base_url: {base}/v1")
     print(f"Cost summary: {base}/_occ/costs")
     uvicorn.run(app, host=host, port=port)
+    return 0
+
+
+def _install(args: argparse.Namespace) -> int:
+    from openai_cost_calculator.adapters.install import (
+        install_claude_code,
+        install_codex,
+    )
+
+    if args.target == "claude-code":
+        messages = install_claude_code(args.scope)
+    elif args.target == "codex":
+        messages = install_codex(args.proxy_url, args.session)
+    else:
+        raise AssertionError(args.target)
+    for message in messages:
+        print(message)
+    print("Undo with: openai-cost-calculator uninstall", args.target)
+    return 0
+
+
+def _uninstall(args: argparse.Namespace) -> int:
+    from openai_cost_calculator.adapters.install import (
+        uninstall_claude_code,
+        uninstall_codex,
+    )
+
+    if args.target == "claude-code":
+        messages = uninstall_claude_code(args.scope)
+    elif args.target == "codex":
+        messages = uninstall_codex()
+    else:
+        raise AssertionError(args.target)
+    for message in messages:
+        print(message)
     return 0
 
 

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -43,8 +43,12 @@ def create_app(
     app.state.occ_transport = transport
 
     @app.get("/_occ/costs")
-    async def costs() -> JSONResponse:
-        return JSONResponse(app.state.occ_registry.summary())
+    async def costs(session: Optional[str] = None) -> JSONResponse:
+        return JSONResponse(app.state.occ_registry.summary(session))
+
+    @app.post("/_occ/checkpoint")
+    async def checkpoint(session: Optional[str] = None) -> JSONResponse:
+        return JSONResponse(app.state.occ_registry.checkpoint(session))
 
     @app.post("/_occ/reset")
     async def reset() -> JSONResponse:

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from decimal import Decimal
 from threading import RLock
-from typing import Dict, Optional
+from typing import Dict, Iterable, Optional
 
 from openai_cost_calculator.tracker import CallRecord, CostTracker
 
@@ -11,6 +11,7 @@ from openai_cost_calculator.tracker import CallRecord, CostTracker
 class TrackerRegistry:
     def __init__(self, on_error=None) -> None:
         self._trackers: Dict[str, CostTracker] = {}
+        self._checkpoint_cursors: Dict[str, int] = {}
         self._subscribers: list[asyncio.Queue] = []
         self._lock = RLock()
         self._on_error = on_error
@@ -50,6 +51,7 @@ class TrackerRegistry:
     def reset(self) -> None:
         with self._lock:
             self._trackers.clear()
+            self._checkpoint_cursors.clear()
         self.notify()
 
     def subscribe(self) -> asyncio.Queue:
@@ -70,9 +72,14 @@ class TrackerRegistry:
         for queue in subscribers:
             queue.put_nowait(summary)
 
-    def summary(self) -> dict:
+    def summary(self, session_id: Optional[str] = None) -> dict:
         with self._lock:
-            trackers = dict(self._trackers)
+            if session_id is None:
+                trackers = dict(self._trackers)
+            else:
+                key = session_id or "default"
+                tracker = self._trackers.get(key)
+                trackers = {key: tracker} if tracker is not None else {}
 
         sessions = {}
         grand_total = Decimal("0")
@@ -87,6 +94,80 @@ class TrackerRegistry:
             "sessions": sessions,
             "grand_total": f"{grand_total:.8f}",
         }
+
+    def checkpoint(self, session_id: Optional[str]) -> dict:
+        key = session_id or "default"
+        with self._lock:
+            tracker = self._trackers.get(key)
+            records = _tracker_records(tracker) if tracker is not None else []
+            cursor = min(self._checkpoint_cursors.get(key, 0), len(records))
+            new_records = records[cursor:]
+            self._checkpoint_cursors[key] = len(records)
+
+        return _records_summary(key, new_records)
+
+
+def _tracker_records(tracker: Optional[CostTracker]) -> list[CallRecord]:
+    if tracker is None:
+        return []
+    records: list[CallRecord] = []
+    for turn in tracker.turns:
+        records.extend(turn.records)
+    records.sort(key=lambda record: record.timestamp)
+    return records
+
+
+def _records_summary(session_id: str, records: Iterable[CallRecord]) -> dict:
+    total_cost = Decimal("0")
+    prompt_tokens = 0
+    completion_tokens = 0
+    cached_tokens = 0
+    models: dict[str, dict] = {}
+    num_calls = 0
+
+    for record in records:
+        num_calls += 1
+        total_cost += record.cost.total_cost
+        prompt_tokens += record.prompt_tokens
+        completion_tokens += record.completion_tokens
+        cached_tokens += record.cached_tokens
+        model = models.setdefault(
+            record.model,
+            {
+                "num_calls": 0,
+                "total_cost": Decimal("0"),
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "cached_tokens": 0,
+            },
+        )
+        model["num_calls"] += 1
+        model["total_cost"] += record.cost.total_cost
+        model["prompt_tokens"] += record.prompt_tokens
+        model["completion_tokens"] += record.completion_tokens
+        model["cached_tokens"] += record.cached_tokens
+
+    stringified_models = {
+        model_name: {
+            **{key: value for key, value in model.items() if key != "total_cost"},
+            "total_cost": f"{model['total_cost']:.8f}",
+        }
+        for model_name, model in models.items()
+    }
+
+    return {
+        "session": session_id,
+        "num_calls": num_calls,
+        "total_cost": f"{total_cost:.8f}",
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cached_tokens": cached_tokens,
+        "models": stringified_models,
+        "cost_by_model": {
+            model_name: model["total_cost"]
+            for model_name, model in stringified_models.items()
+        },
+    }
 
 
 default_registry = TrackerRegistry()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ proxy = [
 
 [project.scripts]
 openai-cost-calculator = "openai_cost_calculator.cli:main"
+occ-cc-statusline = "openai_cost_calculator.adapters.claude_code:statusline_main"
+occ-cc-stop-hook = "openai_cost_calculator.adapters.claude_code:stop_hook_main"
+occ-codex-notify = "openai_cost_calculator.adapters.codex:notify_main"
+occ-codex-statusline = "openai_cost_calculator.adapters.codex:statusline_main"
 
 [tool.setuptools.packages.find]
 include = ["openai_cost_calculator*"]

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setup(
     entry_points={
         "console_scripts": [
             "openai-cost-calculator=openai_cost_calculator.cli:main",
+            "occ-cc-statusline=openai_cost_calculator.adapters.claude_code:statusline_main",
+            "occ-cc-stop-hook=openai_cost_calculator.adapters.claude_code:stop_hook_main",
+            "occ-codex-notify=openai_cost_calculator.adapters.codex:notify_main",
+            "occ-codex-statusline=openai_cost_calculator.adapters.codex:statusline_main",
         ],
     },
     classifiers=[

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from openai_cost_calculator.adapters.claude_code import (
+    statusline_text as claude_statusline_text,
+    stop_hook_output,
+)
+from openai_cost_calculator.adapters.codex import (
+    checkpoint_text,
+    statusline_text as codex_statusline_text,
+)
+from openai_cost_calculator.adapters.install import (
+    install_claude_code,
+    install_codex,
+    uninstall_claude_code,
+    uninstall_codex,
+)
+from openai_cost_calculator.pricing import (
+    add_pricing_entry,
+    clear_local_pricing,
+    set_offline_mode,
+)
+from openai_cost_calculator.proxy.app import create_app
+from openai_cost_calculator.proxy.registry import TrackerRegistry
+
+
+@pytest.fixture(autouse=True)
+def pinned_pricing():
+    clear_local_pricing()
+    set_offline_mode(True)
+    add_pricing_entry(
+        "gpt-test",
+        "2025-01-01",
+        input_price=1.0,
+        output_price=2.0,
+        cached_input_price=0.5,
+    )
+    yield
+    clear_local_pricing()
+    set_offline_mode(False)
+
+
+def test_claude_statusline_formats_tokens_and_handles_null_usage():
+    payload = {
+        "model": {"display_name": "Sonnet 4.6"},
+        "cost": {"total_cost_usd": "0.01234"},
+        "context_window": {
+            "total_input_tokens": 28_000,
+            "context_window_size": 200_000,
+            "current_usage": {
+                "input_tokens": 8_500,
+                "output_tokens": 1_200,
+                "cache_read_input_tokens": 2_000,
+            },
+        },
+    }
+
+    assert claude_statusline_text(payload) == (
+        "💰 $0.0123 session · last 8.5k->1.2k tok "
+        "(cache 2.0k) · Sonnet 4.6 · ctx 14%"
+    )
+
+    payload["context_window"]["current_usage"] = None
+    assert "last -- tok" in claude_statusline_text(payload)
+    assert claude_statusline_text({}).startswith("💰 $0.0000 session")
+
+
+def test_claude_stop_hook_costs_latest_turn_and_dedupes(tmp_path: Path):
+    transcript = tmp_path / "transcript.jsonl"
+    rows = [
+        {"type": "user", "message": {"role": "user", "content": "hi"}},
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "usage": {"input_tokens": 1_000, "output_tokens": 500},
+                "cost_usd": "0.0041",
+            },
+        },
+    ]
+    transcript.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+    payload = {"session_id": "s1", "transcript_path": str(transcript)}
+
+    first = stop_hook_output(payload, cache_dir=tmp_path / "cache")
+    assert first == {"systemMessage": "💰 This turn cost $0.0041 (1.0k in / 500 out)"}
+    second = stop_hook_output(payload, cache_dir=tmp_path / "cache")
+    assert second == {}
+
+
+def test_codex_adapters_render_and_silently_handle_network_errors(monkeypatch):
+    class Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def read(self):
+            return json.dumps(self.payload).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        url = request.full_url
+        if "/_occ/checkpoint" in url:
+            return Response(
+                {
+                    "total_cost": "0.00320000",
+                    "prompt_tokens": 1_200,
+                    "completion_tokens": 500,
+                    "models": {"gpt-5.5": {"total_cost": "0.00320000"}},
+                }
+            )
+        return Response(
+            {
+                "sessions": {
+                    "s1": {
+                        "session_total": "0.01000000",
+                        "turns": [{"total_cost": "0.00320000"}],
+                    }
+                },
+                "grand_total": "0.01000000",
+            }
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    assert checkpoint_text({}, session="s1") == "💰 Turn $0.0032 · gpt-5.5 1.2k->500"
+    assert codex_statusline_text(session="s1") == "💰 $0.0100 session · last $0.0032"
+
+    def failing_urlopen(request, timeout):
+        raise OSError("offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", failing_urlopen)
+    assert checkpoint_text({}, session="s1") is None
+    assert codex_statusline_text(session="s1") == "💰 cost offline"
+
+
+def test_proxy_checkpoint_advances_cursor_and_costs_remain_cumulative():
+    calls = [
+        {
+            "model": "gpt-test-2025-01-01",
+            "usage": {"prompt_tokens": 1_000, "completion_tokens": 0},
+        },
+        {
+            "model": "gpt-test-2025-01-01",
+            "usage": {"prompt_tokens": 0, "completion_tokens": 1_000},
+        },
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "application/json"}, json=calls.pop(0))
+
+    app = create_app(
+        upstream="https://upstream.example/v1",
+        transport=httpx.MockTransport(handler),
+        registry=TrackerRegistry(),
+    )
+    client = TestClient(app)
+    for _ in range(2):
+        client.post("/v1/responses", json={}, headers={"x-occ-session": "s1"})
+
+    first = client.post("/_occ/checkpoint?session=s1").json()
+    assert first["total_cost"] == "0.00300000"
+    assert first["num_calls"] == 2
+    assert first["models"]["gpt-test-2025-01-01"]["completion_tokens"] == 1_000
+    second = client.post("/_occ/checkpoint?session=s1").json()
+    assert second["total_cost"] == "0.00000000"
+    assert client.get("/_occ/costs?session=s1").json()["grand_total"] == "0.00300000"
+
+
+def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    claude_settings = claude_dir / "settings.json"
+    claude_settings.write_text('{"unrelated": true}\n', encoding="utf-8")
+
+    install_claude_code()
+    install_claude_code()
+    settings = json.loads(claude_settings.read_text(encoding="utf-8"))
+    assert settings["unrelated"] is True
+    assert settings["statusLine"]["command"] == "occ-cc-statusline"
+    stop_hooks = settings["hooks"]["Stop"]
+    assert json.dumps(stop_hooks).count("occ-cc-stop-hook") == 1
+    uninstall_claude_code()
+    settings = json.loads(claude_settings.read_text(encoding="utf-8"))
+    assert settings == {"unrelated": True}
+
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir()
+    codex_config = codex_dir / "config.toml"
+    codex_config.write_text(
+        'notify = ["existing-notifier"]\nmodel = "gpt-test"\n',
+        encoding="utf-8",
+    )
+    install_codex("http://127.0.0.1:8100", "s1")
+    install_codex("http://127.0.0.1:8100", "s1")
+    text = codex_config.read_text(encoding="utf-8")
+    assert text.count("openai-cost-calculator") == 2
+    assert text.count("occ-codex-notify") == 1
+    assert "occ-codex-statusline" in text
+    active_notify_lines = [
+        line for line in text.splitlines() if line.startswith('notify = ["')
+    ]
+    assert active_notify_lines == ['notify = ["occ-codex-notify"]']
+    assert "# previous_notify = notify = [\"existing-notifier\"]" in text
+    assert 'model = "gpt-test"' in text
+    uninstall_codex()
+    assert codex_config.read_text(encoding="utf-8").strip() == (
+        'notify = ["existing-notifier"]\nmodel = "gpt-test"'
+    )


### PR DESCRIPTION
Adds Claude Code and Codex adapter entry points for status lines and per-turn cost notifications, including installer and uninstaller CLI support.
Adds a proxy checkpoint endpoint so Codex can report cost accumulated since the previous completed turn while preserving cumulative session totals.
Documents the install flow and covers the adapters, checkpoint behavior, and idempotent installer behavior with offline tests.

Tests: uv run --with pytest --with fastapi --with httpx --with uvicorn --with requests pytest -q