### PR TITLE
Fix Codex cost adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Run the proxy and route Codex's OpenAI-compatible provider through it:
 openai-cost-calculator proxy --port 8100
 ```
 
+The Codex installer adds a managed `~/.codex/config.toml` block that selects an
+`openai_cost_calculator` custom provider, points it at
+`http://127.0.0.1:8100/v1`, uses `wire_api = "responses"`, and disables
+websockets so the HTTP proxy can observe usage. The provider uses
+`OPENAI_API_KEY`, so make sure that environment variable is available to Codex.
+
 Codex notifications use the proxy checkpoint endpoint, so one
 `agent-turn-complete` notification corresponds to one cost checkpoint:
 
@@ -183,9 +189,10 @@ Codex notifications use the proxy checkpoint endpoint, so one
 ```
 
 Codex does not pass token or cost data to `notify`; these numbers come from the
-local proxy. Current Codex docs expose `notify` as an external program and the
-TUI status line as built-in footer items, so `occ-codex-statusline` is provided
-for wrappers or future Codex builds that can run an external status command.
+local proxy. Current Codex docs expose `notify` as an external program; some
+Codex surfaces, including `codex exec`, run the notifier but do not display its
+stdout. `occ-codex-statusline` is provided for wrappers or future Codex builds
+that can run an external status command.
 
 Undo either install with:
 

--- a/index.html
+++ b/index.html
@@ -402,8 +402,15 @@ print(tracker.session_total)</code></pre>
         <h3 id="codex">Codex</h3>
         <p>Install the Codex adapters:</p>
 <pre><button class="copy" data-copy>Copy</button><code>openai-cost-calculator install codex --proxy-url http://127.0.0.1:8100 --session default</code></pre>
-        <p>Run the proxy and route Codex's OpenAI-compatible provider through it:</p>
+        <p>Run the proxy:</p>
 <pre><button class="copy" data-copy>Copy</button><code>openai-cost-calculator proxy --port 8100</code></pre>
+        <p>
+          The Codex installer adds a managed <code>~/.codex/config.toml</code> block that selects an
+          <code>openai_cost_calculator</code> custom provider, points it at
+          <code>http://127.0.0.1:8100/v1</code>, uses <code>wire_api = "responses"</code>, and disables
+          websockets so the HTTP proxy can observe usage. The provider uses <code>OPENAI_API_KEY</code>,
+          so make sure that environment variable is available to Codex.
+        </p>
         <p>
           Codex notifications use the proxy checkpoint endpoint, so one <code>agent-turn-complete</code> notification
           corresponds to one cost checkpoint:
@@ -412,7 +419,8 @@ print(tracker.session_total)</code></pre>
 💰 Turn $0.0032 · gpt-5.5 1.2k->500</code></pre>
         <p>
           Codex does not pass token or cost data to <code>notify</code>; these numbers come from the local proxy. Current
-          Codex docs expose <code>notify</code> as an external program and the TUI status line as built-in footer items, so
+          Codex docs expose <code>notify</code> as an external program; some Codex surfaces, including
+          <code>codex exec</code>, run the notifier but do not display its stdout.
           <code>occ-codex-statusline</code> is provided for wrappers or future Codex builds that can run an external status command.
         </p>
 

--- a/openai_cost_calculator/adapters/codex.py
+++ b/openai_cost_calculator/adapters/codex.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 from decimal import Decimal
+from pathlib import Path
 from typing import Any, Optional
 
 from openai_cost_calculator.adapters.common import (
@@ -45,15 +47,30 @@ def checkpoint_text(
 
 def notify_main() -> int:
     try:
-        notification = json.loads(sys.argv[1]) if len(sys.argv) > 1 else {}
+        raw_notification = _notification_arg()
+        notification = json.loads(raw_notification) if raw_notification else {}
         if not isinstance(notification, dict):
             return 0
         if notification.get("type") != "agent-turn-complete":
+            _run_previous_notify(raw_notification)
             return 0
-        session = os.environ.get("OCC_SESSION") or notification.get("thread-id")
-        line = checkpoint_text(notification, session=session)
+        settings = _codex_adapter_settings()
+        session = (
+            os.environ.get("OCC_SESSION")
+            or settings.get("session")
+            or "default"
+        )
+        line = checkpoint_text(
+            notification,
+            proxy_url=settings.get("proxy_url"),
+            session=session,
+        )
         if line:
             print(line)
+        _run_previous_notify(
+            raw_notification,
+            previous_notify=settings.get("previous_notify"),
+        )
     except Exception:
         return 0
     return 0
@@ -64,10 +81,20 @@ def statusline_text(
     proxy_url: Optional[str] = None,
     session: Optional[str] = None,
 ) -> str:
-    session_id = session or os.environ.get("OCC_SESSION") or "default"
+    settings = _codex_adapter_settings()
+    session_id = (
+        session
+        or os.environ.get("OCC_SESSION")
+        or settings.get("session")
+        or "default"
+    )
     try:
         data = _get_json(
-            _url(proxy_url, "/_occ/costs", {"session": session_id}),
+            _url(
+                proxy_url or settings.get("proxy_url"),
+                "/_occ/costs",
+                {"session": session_id},
+            ),
             timeout=1.0,
         )
         if data is None:
@@ -160,3 +187,103 @@ def _session_data(
         if isinstance(value, dict):
             return value
     return None
+
+
+def _notification_arg() -> Optional[str]:
+    for value in reversed(sys.argv[1:]):
+        value = value.strip()
+        if value.startswith("{") and value.endswith("}"):
+            return value
+    return None
+
+
+def _codex_adapter_settings() -> dict[str, str]:
+    path = (
+        Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+        / "config.toml"
+    )
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return {}
+
+    settings: dict[str, str] = {}
+    in_block = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped == "# >>> openai-cost-calculator":
+            in_block = True
+            continue
+        if stripped == "# <<< openai-cost-calculator":
+            break
+        if not in_block:
+            continue
+        if stripped.startswith("# previous_notify = "):
+            settings["previous_notify"] = stripped.removeprefix(
+                "# previous_notify = "
+            ).strip()
+        elif stripped.startswith("occ_codex_proxy_url"):
+            settings["proxy_url"] = _toml_string_value(stripped)
+        elif stripped.startswith("occ_codex_session"):
+            settings["session"] = _toml_string_value(stripped)
+    return settings
+
+
+def _toml_string_value(line: str) -> str:
+    _, _, value = line.partition("=")
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+    return value
+
+
+def _run_previous_notify(
+    notification: Optional[str],
+    *,
+    previous_notify: Optional[str] = None,
+) -> None:
+    if not notification:
+        return
+    previous_notify = (
+        previous_notify or _codex_adapter_settings().get("previous_notify")
+    )
+    command = _parse_notify_command(previous_notify)
+    if not command or _is_self_notify(command[0]):
+        return
+    try:
+        subprocess.run(
+            [*command, notification],
+            check=False,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+        )
+    except Exception:
+        return
+
+
+def _parse_notify_command(value: Optional[str]) -> Optional[list[str]]:
+    if not value:
+        return None
+    try:
+        import tomllib  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - Python < 3.11 fallback
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except Exception:
+            tomllib = None  # type: ignore[assignment]
+
+    if tomllib is not None:
+        try:
+            parsed = tomllib.loads(value)
+            notify = parsed.get("notify")
+            if isinstance(notify, list) and all(
+                isinstance(item, str) for item in notify
+            ):
+                return notify
+        except Exception:
+            return None
+    return None
+
+
+def _is_self_notify(command: str) -> bool:
+    return Path(command).name in {"occ-codex-notify", "occ-codex-statusline"}

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import time
 from pathlib import Path
@@ -73,31 +74,52 @@ def uninstall_claude_code(scope: str = "user") -> list[str]:
 
 
 def install_codex(proxy_url: str, session: str) -> list[str]:
-    path = Path.home() / ".codex" / "config.toml"
+    path = _codex_config_path()
     text = _read_text(path)
-    previous_notify = _managed_previous_notify(text)
+    previous_notify = _managed_previous_key(text, "notify")
+    previous_model_provider = _managed_previous_key(text, "model_provider")
+    previous_openai_base_url = _managed_previous_key(text, "openai_base_url")
     base = _remove_managed_block(text)
+    if (
+        previous_openai_base_url
+        and _extract_top_level_key(base, "openai_base_url")[0] is None
+    ):
+        base = f"{previous_openai_base_url}\n{base.lstrip()}"
     extracted_notify, base = _extract_top_level_key(base, "notify")
+    extracted_model_provider, base = _extract_top_level_key(base, "model_provider")
     previous_notify = previous_notify or extracted_notify
-    block = _codex_block(proxy_url, session, previous_notify)
-    new_text = _prepend_managed_block(base, block)
+    previous_model_provider = previous_model_provider or extracted_model_provider
+    top_block, provider_block = _codex_blocks(
+        proxy_url,
+        session,
+        previous_notify,
+        previous_model_provider,
+    )
+    new_text = _insert_codex_blocks(base, top_block, provider_block)
     if new_text != text:
         _backup(path)
         _write_text(path, new_text)
         return [
-            f"{path}: installed notify/statusline adapter block",
-            "Route Codex through the proxy with base_url http://127.0.0.1:8100/v1 and X-OCC-Session if your provider supports static headers.",
+            f"{path}: installed Codex cost adapter block",
+            f"Run the proxy with: openai-cost-calculator proxy --port {_proxy_port(proxy_url)}",
+            "Ensure OPENAI_API_KEY is available to Codex for the proxy provider.",
         ]
     return [f"{path}: already installed"]
 
 
 def uninstall_codex() -> list[str]:
-    path = Path.home() / ".codex" / "config.toml"
+    path = _codex_config_path()
     text = _read_text(path)
-    previous_notify = _managed_previous_notify(text)
+    previous_notify = _managed_previous_key(text, "notify")
+    previous_model_provider = _managed_previous_key(text, "model_provider")
     new_text = _remove_managed_block(text)
     if previous_notify and _extract_top_level_key(new_text, "notify")[0] is None:
         new_text = f"{previous_notify}\n{new_text.lstrip()}"
+    if previous_model_provider and _extract_top_level_key(new_text, "model_provider")[0] is None:
+        insert = previous_model_provider
+        if not insert.endswith("\n"):
+            insert = f"{insert}\n"
+        new_text = f"{insert}{new_text.lstrip()}"
     if new_text != text:
         _backup(path)
         _write_text(path, new_text)
@@ -109,6 +131,10 @@ def _claude_settings_path(scope: str) -> Path:
     if scope == "project":
         return Path.cwd() / ".claude" / "settings.json"
     return Path.home() / ".claude" / "settings.json"
+
+
+def _codex_config_path() -> Path:
+    return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex") / "config.toml"
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:
@@ -186,26 +212,44 @@ def _remove_hook(entry: Any, command: str) -> Any:
     return next_entry
 
 
-def _codex_block(
+def _codex_blocks(
     proxy_url: str,
     session: str,
     previous_notify: Optional[str] = None,
-) -> str:
+    previous_model_provider: Optional[str] = None,
+) -> tuple[str, str]:
     escaped_proxy = proxy_url.replace("\\", "\\\\").replace('"', '\\"')
+    api_base = _proxy_api_base(proxy_url)
+    escaped_api_base = api_base.replace("\\", "\\\\").replace('"', '\\"')
     escaped_session = session.replace("\\", "\\\\").replace('"', '\\"')
-    previous = f"# previous_notify = {previous_notify}\n" if previous_notify else ""
-    return (
+    previous = ""
+    if previous_notify:
+        previous += f"# previous_notify = {previous_notify}\n"
+    if previous_model_provider:
+        previous += f"# previous_model_provider = {previous_model_provider}\n"
+    top_block = (
         f"{CODEX_BEGIN}\n"
-        '# Codex notify is documented as an external program. Current Codex\n'
-        '# docs expose TUI status_line as built-in item identifiers, so the\n'
-        '# statusline command is stored here for wrappers that support it.\n'
+        "# OpenAI Cost Calculator routes Codex through the local proxy\n"
+        "# and prints a checkpoint after each turn.\n"
         f"{previous}"
         'notify = ["occ-codex-notify"]\n'
+        'model_provider = "openai_cost_calculator"\n'
         f'occ_codex_proxy_url = "{escaped_proxy}"\n'
         f'occ_codex_session = "{escaped_session}"\n'
         'occ_codex_statusline_command = "occ-codex-statusline"\n'
         f"{CODEX_END}\n"
     )
+    provider_block = (
+        f"{CODEX_BEGIN}\n"
+        "[model_providers.openai_cost_calculator]\n"
+        'name = "OpenAI Cost Calculator Proxy"\n'
+        f'base_url = "{escaped_api_base}"\n'
+        'env_key = "OPENAI_API_KEY"\n'
+        'wire_api = "responses"\n'
+        "supports_websockets = false\n"
+        f"{CODEX_END}\n"
+    )
+    return top_block, provider_block
 
 
 def _prepend_managed_block(text: str, block: str) -> str:
@@ -213,6 +257,22 @@ def _prepend_managed_block(text: str, block: str) -> str:
     if stripped:
         return f"{block}\n{stripped}\n"
     return block
+
+
+def _insert_codex_blocks(text: str, top_block: str, provider_block: str) -> str:
+    base = _remove_managed_block(text).strip()
+    if not base:
+        return f"{top_block}\n{provider_block}"
+    top_level, sections = _split_first_section(base)
+    top_level = top_level.strip()
+    sections = sections.strip()
+    parts = [top_block.rstrip()]
+    if top_level:
+        parts.append(top_level)
+    parts.append(provider_block.rstrip())
+    if sections:
+        parts.append(sections)
+    return "\n\n".join(parts) + "\n"
 
 
 def _remove_managed_block(text: str) -> str:
@@ -231,7 +291,8 @@ def _remove_managed_block(text: str) -> str:
     return "".join(output).rstrip() + ("\n" if output else "")
 
 
-def _managed_previous_notify(text: str) -> Optional[str]:
+def _managed_previous_key(text: str, key: str) -> Optional[str]:
+    marker = f"# previous_{key} = "
     in_block = False
     for line in text.splitlines():
         if line.strip() == CODEX_BEGIN:
@@ -239,8 +300,8 @@ def _managed_previous_notify(text: str) -> Optional[str]:
             continue
         if line.strip() == CODEX_END:
             return None
-        if in_block and line.startswith("# previous_notify = "):
-            value = line.removeprefix("# previous_notify = ").strip()
+        if in_block and line.startswith(marker):
+            value = line.removeprefix(marker).strip()
             return value or None
     return None
 
@@ -263,3 +324,29 @@ def _extract_top_level_key(text: str, key: str) -> Tuple[Optional[str], str]:
             continue
         output.append(line)
     return found, "".join(output)
+
+
+def _split_first_section(text: str) -> tuple[str, str]:
+    lines = text.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            return "".join(lines[:index]), "".join(lines[index:])
+    return text, ""
+
+
+def _proxy_api_base(proxy_url: str) -> str:
+    base = proxy_url.rstrip("/")
+    if base.endswith("/v1"):
+        return base
+    return f"{base}/v1"
+
+
+def _proxy_port(proxy_url: str) -> str:
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(proxy_url)
+        return str(parsed.port or 8100)
+    except Exception:
+        return "8100"

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -310,11 +310,18 @@ class _SSEUsageParser:
         if raw_data == "[DONE]":
             return
         payload = _json_from_bytes(raw_data.encode("utf-8"))
-        if not payload or extract_usage_from_payload(payload) is None:
+        if not payload:
             return
-        if "model" not in payload and isinstance(self._default_model, str):
-            payload = {**payload, "model": self._default_model}
-        self.usage_payload = payload
+        usage_payload = payload
+        if extract_usage_from_payload(usage_payload) is None:
+            nested_response = payload.get("response")
+            if isinstance(nested_response, dict):
+                usage_payload = nested_response
+        if extract_usage_from_payload(usage_payload) is None:
+            return
+        if "model" not in usage_payload and isinstance(self._default_model, str):
+            usage_payload = {**usage_payload, "model": self._default_model}
+        self.usage_payload = usage_payload
 
 
 app = create_app()

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -14,6 +14,7 @@ from openai_cost_calculator.adapters.claude_code import (
 )
 from openai_cost_calculator.adapters.codex import (
     checkpoint_text,
+    notify_main,
     statusline_text as codex_statusline_text,
 )
 from openai_cost_calculator.adapters.install import (
@@ -143,6 +144,69 @@ def test_codex_adapters_render_and_silently_handle_network_errors(monkeypatch):
     assert codex_statusline_text(session="s1") == "💰 cost offline"
 
 
+def test_codex_notify_uses_installed_session_and_chains_previous_notifier(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    previous_log = tmp_path / "previous.log"
+    previous = tmp_path / "previous.py"
+    previous.write_text(
+        "import pathlib, sys\n"
+        f"pathlib.Path({str(previous_log)!r}).write_text(sys.argv[-1])\n",
+        encoding="utf-8",
+    )
+    (codex_home / "config.toml").write_text(
+        "# >>> openai-cost-calculator\n"
+        f"# previous_notify = notify = [\"python3\", \"{previous}\"]\n"
+        'notify = ["occ-codex-notify"]\n'
+        'model_provider = "openai_cost_calculator"\n'
+        'occ_codex_proxy_url = "http://127.0.0.1:8100"\n'
+        'occ_codex_session = "installed-session"\n'
+        'occ_codex_statusline_command = "occ-codex-statusline"\n'
+        "# <<< openai-cost-calculator\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    requested_urls = []
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+        def read(self):
+            return json.dumps(
+                {
+                    "total_cost": "0.00400000",
+                    "prompt_tokens": 2_000,
+                    "completion_tokens": 1_000,
+                    "models": {"gpt-test": {"total_cost": "0.00400000"}},
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        requested_urls.append(request.full_url)
+        return Response()
+
+    notification = {
+        "type": "agent-turn-complete",
+        "thread-id": "thread-session",
+    }
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setattr("sys.argv", ["occ-codex-notify", json.dumps(notification)])
+
+    assert notify_main() == 0
+    assert "💰 Turn $0.0040 · gpt-test 2.0k->1.0k" in capsys.readouterr().out
+    assert "session=installed-session" in requested_urls[0]
+    assert json.loads(previous_log.read_text(encoding="utf-8")) == notification
+
+
 def test_proxy_checkpoint_advances_cursor_and_costs_remain_cumulative():
     calls = [
         {
@@ -198,22 +262,31 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
     codex_dir.mkdir()
     codex_config = codex_dir / "config.toml"
     codex_config.write_text(
-        'notify = ["existing-notifier"]\nmodel = "gpt-test"\n',
+        'notify = ["existing-notifier"]\n'
+        'model_provider = "existing-provider"\n'
+        'model = "gpt-test"\n',
         encoding="utf-8",
     )
     install_codex("http://127.0.0.1:8100", "s1")
     install_codex("http://127.0.0.1:8100", "s1")
     text = codex_config.read_text(encoding="utf-8")
-    assert text.count("openai-cost-calculator") == 2
+    assert text.count("openai-cost-calculator") == 4
     assert text.count("occ-codex-notify") == 1
     assert "occ-codex-statusline" in text
+    assert 'model_provider = "openai_cost_calculator"' in text
+    assert "[model_providers.openai_cost_calculator]" in text
+    assert 'base_url = "http://127.0.0.1:8100/v1"' in text
+    assert "supports_websockets = false" in text
     active_notify_lines = [
         line for line in text.splitlines() if line.startswith('notify = ["')
     ]
     assert active_notify_lines == ['notify = ["occ-codex-notify"]']
     assert "# previous_notify = notify = [\"existing-notifier\"]" in text
+    assert '# previous_model_provider = model_provider = "existing-provider"' in text
     assert 'model = "gpt-test"' in text
     uninstall_codex()
     assert codex_config.read_text(encoding="utf-8").strip() == (
-        'notify = ["existing-notifier"]\nmodel = "gpt-test"'
+        'model_provider = "existing-provider"\n'
+        'notify = ["existing-notifier"]\n'
+        'model = "gpt-test"'
     )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -153,6 +153,44 @@ def test_streaming_sse_passes_body_through_and_costs_final_usage_event():
     assert costs["sessions"]["stream-session"]["session_total"] == "0.00775000"
 
 
+def test_streaming_responses_completed_event_costs_nested_usage():
+    completed = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp-test",
+            "model": "gpt-test-2025-01-01",
+            "usage": {
+                "input_tokens": 1_000,
+                "output_tokens": 2_000,
+                "input_tokens_details": {"cached_tokens": 100},
+            },
+        },
+    }
+    chunks = [
+        b'event: response.output_text.delta\ndata: {"delta":"hi"}\n\n',
+        f"event: response.completed\ndata: {json.dumps(completed)}\n\n".encode("utf-8"),
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads((await request.aread()).decode("utf-8"))["stream"] is True
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=AsyncChunkStream(chunks),
+        )
+
+    client = _client(handler)
+    response = client.post(
+        "/v1/responses",
+        json={"model": "gpt-test-2025-01-01", "stream": True},
+        headers={"x-occ-session": "responses-stream"},
+    )
+
+    assert response.content == b"".join(chunks)
+    costs = client.get("/_occ/costs").json()
+    assert costs["sessions"]["responses-stream"]["session_total"] == "0.00495000"
+
+
 def test_costs_endpoint_reflects_turn_grouping():
     calls = [
         {


### PR DESCRIPTION
Fixes the Codex cost adapter so installs configure a working custom provider through the local proxy instead of relying on the built-in OpenAI websocket path. The notifier now uses the installed session/proxy settings, chains any previous notifier, and the proxy can cost nested Responses streaming usage from `response.completed` events. README and `index.html` now document the working Codex setup and the `codex exec` notifier stdout caveat.

Validation: `/opt/homebrew/bin/python3.11 -m pytest` passed with 48 tests.
