### PR TITLE
Update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/pricing-check.yml
+++ b/.github/workflows/pricing-check.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Open Pricing Update PR
         if: steps.pricing_diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: automated/pricing-update
           title: Update model pricing from upstream

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set Up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Updates GitHub Actions that were still targeting the deprecated Node 20 runtime to Node 24-compatible major versions.

This bumps checkout and setup-python in the test and pricing workflows, and updates the automated pricing PR action to its Node 24-compatible major.

Validated with `python3.11 -m pytest -q`.
