### PR TITLE
Harden Codex cost observation for production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Status output separates `historical_total` loaded at startup from `process_total
 One ledger supports exactly one proxy process at a time.
 The proxy holds an exclusive file lock and refuses a second writer instead of claiming unsupported cross-process safety.
 Use a different ledger for each simultaneously running proxy.
+The lightweight snapshot design is intended for a local observer, not a high-throughput shared gateway.
+To keep memory and storage failure modes bounded, one proxy accepts up to 1,024 sessions and 50,000 calls per session, retains at most 100 diagnostics per session, and reports `accounting_capacity_reached` instead of silently dropping into a false zero-cost success.
 
 Inspect or reset an offline ledger with:
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Install the optional proxy dependencies:
 pip install openai-cost-calculator[proxy]
 ```
 
-Run the local OpenAI-compatible proxy:
+Run the local OpenAI-compatible proxy for a Platform API-key client:
 
 ```bash
-openai-cost-calculator proxy --port 8100
+openai-cost-calculator proxy --port 8100 --auth-mode api-key
 ```
 
 Point any OpenAI-compatible agent, IDE, or SDK client at:
@@ -120,13 +120,18 @@ Point any OpenAI-compatible agent, IDE, or SDK client at:
 http://127.0.0.1:8100/v1
 ```
 
-The proxy forwards requests to `https://api.openai.com/v1` by default, preserving
-the request body and `Authorization` header. To use another OpenAI-compatible
-upstream:
+The proxy forwards Platform API-key requests to `https://api.openai.com/v1` and ChatGPT-backed Codex requests to `https://chatgpt.com/backend-api/codex`.
+`--auth-mode auto` reads only the `auth_mode` field in Codex authentication metadata and otherwise retains the backward-compatible Platform default.
+It never silently retries a request against the other authentication domain.
+Known-incompatible authentication and upstream combinations fail at startup.
+To use a trusted OpenAI-compatible upstream explicitly:
 
 ```bash
-openai-cost-calculator proxy --port 8100 --upstream https://example.com/v1
+openai-cost-calculator proxy --port 8100 --auth-mode api-key --upstream https://example.com/v1
 ```
+
+An explicit custom upstream receives the forwarded `Authorization` header, so only configure an endpoint you trust.
+The proxy removes hop-by-hop transport headers and its local `X-OCC-Session` and `X-OCC-Turn` headers while preserving required end-to-end headers.
 
 Read accumulated costs at:
 
@@ -134,10 +139,49 @@ Read accumulated costs at:
 http://127.0.0.1:8100/_occ/costs
 ```
 
-For grouping, send `X-OCC-Session` to separate agent sessions and `X-OCC-Turn`
-to group calls within a visible turn. Streaming calls should set
-`stream_options={"include_usage": true}` so the final SSE usage event can be
-costed.
+For grouping, send `X-OCC-Session` to separate agent sessions and `X-OCC-Turn` to group calls within a visible turn.
+Calls without a session use `default`, and calls with the same session and turn label aggregate into one turn.
+Streaming calls should set `stream_options={"include_usage": true}` so the final SSE usage event can be costed.
+The proxy forwards streaming bytes incrementally and performs accounting only as a side effect.
+An accounting failure never replaces or edits a successful upstream response.
+
+Cached input is removed from uncached input before pricing, then charged only at the cached-input rate.
+Malformed usage where cached input exceeds total input is reported as a diagnostic and is not recorded as a zero-cost success.
+Pricing is selected by model alias, model date, and the highest applicable minimum-token tier.
+
+### Durable accounting
+
+Accounting is in memory by default and is lost when the proxy exits.
+Enable the optional durable JSON ledger when totals must survive restarts:
+
+```bash
+openai-cost-calculator proxy --port 8100 --auth-mode auto --ledger ~/.local/state/openai-cost-calculator/ledger.json
+```
+
+The ledger stores model names, token counts, calculated `Decimal` cost components, turn labels, bounded diagnostics, and checkpoint cursors.
+It never stores request or response bodies, authorization headers, cookies, or authentication files.
+Writes use a same-directory temporary file, `fsync`, and atomic replacement, so an interrupted write leaves the last complete ledger usable.
+Historical calls retain their originally calculated prices rather than being repriced after a restart.
+Status output separates `historical_total` loaded at startup from `process_total` observed by the current proxy.
+
+One ledger supports exactly one proxy process at a time.
+The proxy holds an exclusive file lock and refuses a second writer instead of claiming unsupported cross-process safety.
+Use a different ledger for each simultaneously running proxy.
+
+Inspect or reset an offline ledger with:
+
+```bash
+openai-cost-calculator ledger inspect ~/.local/state/openai-cost-calculator/ledger.json
+openai-cost-calculator ledger reset ~/.local/state/openai-cost-calculator/ledger.json --yes
+```
+
+Use the proxy reset command while the proxy owns the ledger:
+
+```bash
+openai-cost-calculator reset --yes
+```
+
+Reset is destructive and clears cumulative totals, diagnostics, and checkpoint cursors.
 
 ---
 
@@ -168,10 +212,10 @@ Install the Codex adapters:
 openai-cost-calculator install codex --proxy-url http://127.0.0.1:8100 --session default
 ```
 
-Run the proxy and route Codex's OpenAI-compatible provider through it:
+Run the proxy and let it select the route from Codex's existing login metadata:
 
 ```bash
-openai-cost-calculator proxy --port 8100
+openai-cost-calculator proxy --port 8100 --auth-mode auto
 ```
 
 The Codex installer adds a managed `~/.codex/config.toml` block that selects an
@@ -181,27 +225,43 @@ websockets so the HTTP proxy can observe usage.
 The provider uses Codex's existing OpenAI authentication, so sign in with ChatGPT or an API key before using the integration.
 The configured session is sent as an `X-OCC-Session` header so proxy accounting and notifications use the same isolated session.
 
-The proxy's upstream must match the Codex login method.
-For an API-key login, use the default command shown above.
-For a ChatGPT login, run:
+Use an explicit mode when automatic detection is unavailable:
 
 ```bash
-openai-cost-calculator proxy --port 8100 --upstream https://chatgpt.com/backend-api/codex
+openai-cost-calculator proxy --port 8100 --auth-mode chatgpt
+openai-cost-calculator proxy --port 8100 --auth-mode api-key
 ```
 
-Codex notifications use the proxy checkpoint endpoint, so one
-`agent-turn-complete` notification corresponds to one cost checkpoint:
+Codex notifications use the proxy checkpoint endpoint, so one `agent-turn-complete` notification consumes all calls since the preceding successful checkpoint:
 
 ```text
 💰 $0.0188 session · last $0.0032
 💰 Turn $0.0032 · gpt-5.5 1.2k->500
 ```
 
-Codex does not pass token or cost data to `notify`; these numbers come from the
-local proxy. Current Codex docs expose `notify` as an external program; some
-Codex surfaces, including `codex exec`, run the notifier but do not display its
-stdout. `occ-codex-statusline` is provided for wrappers or future Codex builds
-that can run an external status command.
+Checkpoint consumption is incremental and exactly once from the package's perspective.
+Repeating a notifier after a successful checkpoint returns zero and does not change cumulative session totals.
+If a durable cursor cannot be written, the checkpoint fails and remains unconsumed.
+Status reads never consume checkpoints or mutate totals.
+
+Codex does not pass token or cost data to `notify`; these numbers come from the local proxy.
+Some Codex surfaces, including `codex exec`, run the notifier but do not display its stdout.
+Notifier failures never fail Codex and are written to a bounded, permission-protected diagnostic file in `CODEX_HOME`.
+Inspect proxy and notifier diagnostics without reading internal files:
+
+```bash
+openai-cost-calculator status --session default --diagnostics
+openai-cost-calculator status --session default --json
+openai-cost-calculator checkpoint --session default --json
+```
+
+`occ-codex-statusline` remains available for wrappers or Codex surfaces that can run an external status command.
+
+The installer changes only managed blocks plus the top-level `notify` and `model_provider` keys it must replace.
+It preserves the previous values inside the managed block so uninstall can restore them.
+It uses permission-preserving atomic replacement and refuses invalid TOML, malformed managed markers, symlinked configuration, or an existing user-owned provider named `openai_cost_calculator`.
+It does not copy the configuration into retained backup files because user configuration may contain secrets.
+If safe automatic merging is impossible, installation stops before modifying the file.
 
 Undo either install with:
 
@@ -221,6 +281,8 @@ python scripts/self_test_codex_integration.py
 The script uses a free local port and a unique session, creates an isolated temporary `CODEX_HOME`, installs the adapter through the public CLI, copies an existing file-backed Codex login or imports `OPENAI_API_KEY` without printing it, launches one read-only `codex exec` turn, independently recomputes the cost from the working-tree pricing CSV, verifies checkpoint stability, and removes all temporary files.
 Use `--model` or `--upstream` only when the detected Codex login needs an explicit override.
 The command exits nonzero with a sanitized diagnostic when credentials, model access, routing, usage, pricing, or accounting validation fails.
+The live test is opt-in, makes exactly one paid model request when authentication succeeds, and costs whatever that request's selected model and token usage cost.
+Ordinary unit tests never contact an OpenAI service.
 
 ---
 
@@ -317,9 +379,19 @@ Recoverable issues raise `CostEstimateError` with a clear message (missing prici
 
 ## Troubleshooting
 
-- **“Pricing not found”** → confirm row exists in the CSV; call `refresh_pricing()`.  
-- **`cached_tokens = 0`** → ensure `include_usage_details=True` (classic) or `stream_options={"include_usage": True}` (streaming).  
-- **Model string has no date** → the latest row with `date ≤ today` is used.
+- **401 from `api.openai.com` with a ChatGPT login** → restart with `--auth-mode chatgpt`; ChatGPT-backed Codex credentials are not Platform API keys.
+- **401 from `chatgpt.com/backend-api/codex` with an API key** → restart with `--auth-mode api-key`; the proxy never falls back between authentication domains.
+- **Unsupported or inaccessible model** → confirm the selected login has access and that the isolated self-test inherited the intended source model, or pass `--model` explicitly.
+- **“Pricing not found” or `cost_estimation_failed`** → run `openai-cost-calculator pricing validate`, confirm the model has a pricing row, and inspect `openai-cost-calculator status --diagnostics`.
+- **`missing_usage`** → for streaming Chat Completions request final usage with `stream_options={"include_usage": true}`; the proxy cannot infer tokens from response text.
+- **`cached_tokens = 0`** → the upstream did not report cached-token details; missing cached fields are treated as zero, not guessed.
+- **Model string has no date** → the latest pricing row with `date ≤ today` is used, including intentionally undated aliases.
+- **Notifier output is hidden** → use `openai-cost-calculator status --diagnostics`; Codex execution does not depend on notifier stdout.
+- **Ledger is already in use** → inspect through the running proxy or stop it before using offline `ledger` commands.
+- **Ledger health is `ERROR`** → current in-memory totals may be newer than the last durable snapshot; fix the filesystem error before relying on restart recovery.
+
+The administrative `/_occ` endpoints have no authentication.
+Keep the default loopback bind unless a separate trusted access-control layer protects the proxy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ openai-cost-calculator proxy --port 8100 --auth-mode api-key --upstream https://
 
 An explicit custom upstream receives the forwarded `Authorization` header, so only configure an endpoint you trust.
 The proxy removes hop-by-hop transport headers and its local `X-OCC-Session` and `X-OCC-Turn` headers while preserving required end-to-end headers.
+HTTP streaming and WebSocket messages are relayed incrementally without changing upstream bytes, message types, ordering, queries, or negotiated subprotocols.
+Terminal WebSocket Responses events are costed immediately, and duplicate terminal events are ignored.
 
 Read accumulated costs at:
 
@@ -152,30 +154,43 @@ Pricing is selected by model alias, model date, and the highest applicable minim
 ### Durable accounting
 
 Accounting is in memory by default and is lost when the proxy exits.
-Enable the optional durable JSON ledger when totals must survive restarts:
+Use the SQLite backend when totals must survive restarts or more than one proxy process must share accounting state:
 
 ```bash
-openai-cost-calculator proxy --port 8100 --auth-mode auto --ledger ~/.local/state/openai-cost-calculator/ledger.json
+openai-cost-calculator proxy --port 8100 --auth-mode auto --database ~/.local/state/openai-cost-calculator/accounting.sqlite3
 ```
 
-The ledger stores model names, token counts, calculated `Decimal` cost components, turn labels, bounded diagnostics, and checkpoint cursors.
+SQLite uses WAL, full synchronous transactions, concurrent readers and writers, incremental call inserts, streamed summaries, and an atomic checkpoint transaction.
+It works across platforms supported by Python's standard `sqlite3` module and does not rely on POSIX file locking.
+Several proxy processes may share one local SQLite database, and the first successful checkpoint transaction consumes each call exactly once across those processes.
+SQLite storage is not supported on filesystems whose locking semantics are incompatible with SQLite, including many network filesystem configurations.
+
+The database stores model names, token counts, calculated `Decimal` cost components, turn labels, bounded diagnostics, and checkpoint cursors.
 It never stores request or response bodies, authorization headers, cookies, or authentication files.
-Writes use a same-directory temporary file, `fsync`, and atomic replacement, so an interrupted write leaves the last complete ledger usable.
 Historical calls retain their originally calculated prices rather than being repriced after a restart.
-Status output separates `historical_total` loaded at startup from `process_total` observed by the current proxy.
+Status output separates `historical_total` present at startup from `process_total` added since startup.
+After a reset by any process, all connected processes detect the new storage generation and restart those process-relative totals safely.
 
-One ledger supports exactly one proxy process at a time.
-The proxy holds an exclusive file lock and refuses a second writer instead of claiming unsupported cross-process safety.
-Use a different ledger for each simultaneously running proxy.
-The lightweight snapshot design is intended for a local observer, not a high-throughput shared gateway.
-To keep memory and storage failure modes bounded, one proxy accepts up to 1,024 sessions and 50,000 calls per session, retains at most 100 diagnostics per session, and reports `accounting_capacity_reached` instead of silently dropping into a false zero-cost success.
-
-Inspect or reset an offline ledger with:
+Inspect or reset the database while proxies are running or stopped:
 
 ```bash
+openai-cost-calculator database inspect ~/.local/state/openai-cost-calculator/accounting.sqlite3
+openai-cost-calculator database reset ~/.local/state/openai-cost-calculator/accounting.sqlite3 --yes
+```
+
+The previous atomic JSON snapshot backend remains available for compatibility:
+
+```bash
+openai-cost-calculator proxy --port 8100 --ledger ~/.local/state/openai-cost-calculator/ledger.json
 openai-cost-calculator ledger inspect ~/.local/state/openai-cost-calculator/ledger.json
 openai-cost-calculator ledger reset ~/.local/state/openai-cost-calculator/ledger.json --yes
 ```
+
+JSON ledgers remain single-process and POSIX-only; new installations should use SQLite.
+JSON writes use a same-directory temporary file, `fsync`, exclusive locking, and atomic replacement.
+To keep legacy in-memory snapshots bounded, JSON mode accepts up to 1,024 sessions and 50,000 calls per session.
+SQLite removes the per-session call-history limit and aggregates summaries and checkpoints without reconstructing every historical call in memory.
+Both backends retain at most 100 diagnostics per session and report capacity or storage failures explicitly.
 
 Use the proxy reset command while the proxy owns the ledger:
 
@@ -184,6 +199,25 @@ openai-cost-calculator reset --yes
 ```
 
 Reset is destructive and clears cumulative totals, diagnostics, and checkpoint cursors.
+
+### Remote exposure and administrative authentication
+
+The proxy binds to loopback by default.
+A non-loopback bind is refused unless remote exposure is explicit and a strong administrative bearer token is configured.
+Create a permission-protected token file and pass only its path:
+
+```bash
+mkdir -p ~/.config/openai-cost-calculator
+python -c 'import secrets; print(secrets.token_urlsafe(48))' > ~/.config/openai-cost-calculator/admin-token
+chmod 600 ~/.config/openai-cost-calculator/admin-token
+OCC_ADMIN_TOKEN_FILE=~/.config/openai-cost-calculator/admin-token \
+  openai-cost-calculator proxy --host 0.0.0.0 --allow-remote --auth-mode auto
+```
+
+When configured, the token protects every `/_occ` endpoint, including status streams and mutation commands.
+The CLI, notifier, and status line read `OCC_ADMIN_TOKEN` or `OCC_ADMIN_TOKEN_FILE` and send the token only in the administrative `Authorization` header.
+Tokens must contain at least 32 characters, token files must not be accessible by group or others, and token values are never printed or persisted by the package.
+Remote deployments must additionally use TLS and trusted network controls, normally through a reverse proxy.
 
 ---
 
@@ -222,8 +256,8 @@ openai-cost-calculator proxy --port 8100 --auth-mode auto
 
 The Codex installer adds a managed `~/.codex/config.toml` block that selects an
 `openai_cost_calculator` custom provider, points it at
-`http://127.0.0.1:8100/v1`, uses `wire_api = "responses"`, and disables
-websockets so the HTTP proxy can observe usage.
+`http://127.0.0.1:8100/v1`, uses `wire_api = "responses"`, and enables
+WebSockets because both HTTP and WebSocket Responses traffic is observed.
 The provider uses Codex's existing OpenAI authentication, so sign in with ChatGPT or an API key before using the integration.
 The configured session is sent as an `X-OCC-Session` header so proxy accounting and notifications use the same isolated session.
 
@@ -259,8 +293,10 @@ openai-cost-calculator checkpoint --session default --json
 
 `occ-codex-statusline` remains available for wrappers or Codex surfaces that can run an external status command.
 
-The installer changes only managed blocks plus the top-level `notify` and `model_provider` keys it must replace.
-It preserves the previous values inside the managed block so uninstall can restore them.
+The installer changes only managed blocks plus the top-level `notify` and `model_provider` assignments it must replace.
+Those assignments are converted in place to reversible lexical placeholders rather than moved or normalized.
+Unrelated comments, whitespace, quoting, Unicode, line endings, section order, inline comments, and the presence or absence of a final newline are preserved byte-for-byte.
+Uninstall decodes the original assignment bytes at their original locations, while unrelated user edits made after installation remain intact.
 It uses permission-preserving atomic replacement and refuses invalid TOML, malformed managed markers, symlinked configuration, or an existing user-owned provider named `openai_cost_calculator`.
 It does not copy the configuration into retained backup files because user configuration may contain secrets.
 If safe automatic merging is impossible, installation stops before modifying the file.
@@ -282,6 +318,14 @@ python scripts/self_test_codex_integration.py
 
 The script uses a free local port and a unique session, creates an isolated temporary `CODEX_HOME`, installs the adapter through the public CLI, copies an existing file-backed Codex login or imports `OPENAI_API_KEY` without printing it, launches one read-only `codex exec` turn, independently recomputes the cost from the working-tree pricing CSV, verifies checkpoint stability, and removes all temporary files.
 Use `--model` or `--upstream` only when the detected Codex login needs an explicit override.
+Use `--auth-mode chatgpt` to require an isolated copy of an existing ChatGPT login.
+Use `--auth-mode api-key` to require `OPENAI_API_KEY` and exercise the Platform route even when the source Codex installation is logged in through ChatGPT:
+
+```bash
+OPENAI_API_KEY=... python scripts/self_test_codex_integration.py --auth-mode api-key --model MODEL
+```
+
+The API key is passed to `codex login --with-api-key` over stdin and never appears in a command line or report.
 The command exits nonzero with a sanitized diagnostic when credentials, model access, routing, usage, pricing, or accounting validation fails.
 The live test is opt-in, makes exactly one paid model request when authentication succeeds, and costs whatever that request's selected model and token usage cost.
 Ordinary unit tests never contact an OpenAI service.
@@ -389,11 +433,14 @@ Recoverable issues raise `CostEstimateError` with a clear message (missing prici
 - **`cached_tokens = 0`** → the upstream did not report cached-token details; missing cached fields are treated as zero, not guessed.
 - **Model string has no date** → the latest pricing row with `date ≤ today` is used, including intentionally undated aliases.
 - **Notifier output is hidden** → use `openai-cost-calculator status --diagnostics`; Codex execution does not depend on notifier stdout.
-- **Ledger is already in use** → inspect through the running proxy or stop it before using offline `ledger` commands.
+- **JSON ledger is already in use** → inspect through the running proxy, stop it before using offline `ledger` commands, or migrate future operation to SQLite with `--database`.
 - **Ledger health is `ERROR`** → current in-memory totals may be newer than the last durable snapshot; fix the filesystem error before relying on restart recovery.
+- **`admin_auth_required`** → set the same `OCC_ADMIN_TOKEN` or `OCC_ADMIN_TOKEN_FILE` for the proxy, CLI, notifier, and status-line processes.
+- **Remote bind refused** → add `--allow-remote` and a protected administrative token only after TLS and network access controls are ready.
+- **`websocket_missing_terminal`** → the upstream connection closed before a terminal Responses event; inspect diagnostics and upstream connectivity without assuming a zero-cost success.
+- **WebSocket handshake failure** → confirm the selected authentication domain, custom upstream WebSocket support, forwarded subprotocol, and proxy optional dependencies.
 
-The administrative `/_occ` endpoints have no authentication.
-Keep the default loopback bind unless a separate trusted access-control layer protects the proxy.
+Keep the default loopback bind unless remote access is operationally necessary.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -256,8 +256,15 @@ openai-cost-calculator proxy --port 8100 --auth-mode auto
 
 The Codex installer adds a managed `~/.codex/config.toml` block that selects an
 `openai_cost_calculator` custom provider, points it at
-`http://127.0.0.1:8100/v1`, uses `wire_api = "responses"`, and enables
-WebSockets because both HTTP and WebSocket Responses traffic is observed.
+`http://127.0.0.1:8100/v1`, and uses `wire_api = "responses"`.
+HTTP is the default because it preserves the validated one-request self-test behavior.
+The proxy also observes Responses WebSocket traffic; opt in when desired:
+
+```bash
+openai-cost-calculator install codex --websockets --proxy-url http://127.0.0.1:8100 --session default
+```
+
+Codex may issue more than one Responses request for one CLI turn when its WebSocket transport is enabled, and every completed response is accounted independently.
 The provider uses Codex's existing OpenAI authentication, so sign in with ChatGPT or an API key before using the integration.
 The configured session is sent as an `X-OCC-Session` header so proxy accounting and notifications use the same isolated session.
 

--- a/openai_cost_calculator/adapters/codex.py
+++ b/openai_cost_calculator/adapters/codex.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -232,6 +233,9 @@ def _codex_adapter_settings() -> dict[str, str]:
         return {}
 
     settings: dict[str, str] = {}
+    stashed_notify = _stashed_codex_assignment(text, "notify")
+    if stashed_notify:
+        settings["previous_notify"] = stashed_notify.strip()
     in_block = False
     for line in text.splitlines():
         stripped = line.strip()
@@ -251,6 +255,23 @@ def _codex_adapter_settings() -> dict[str, str]:
         elif stripped.startswith("occ_codex_session"):
             settings["session"] = _toml_string_value(stripped)
     return settings
+
+
+def _stashed_codex_assignment(text: str, key: str) -> Optional[str]:
+    marker = f"# occ-restore-{key} = "
+    for line in text.splitlines():
+        if not line.startswith(marker):
+            continue
+        encoded = line.removeprefix(marker).strip()
+        try:
+            return base64.b64decode(
+                encoded,
+                altchars=b"-_",
+                validate=True,
+            ).decode("utf-8")
+        except Exception:
+            return None
+    return None
 
 
 def _toml_string_value(line: str) -> str:

--- a/openai_cost_calculator/adapters/codex.py
+++ b/openai_cost_calculator/adapters/codex.py
@@ -4,12 +4,14 @@ import json
 import os
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, Optional
+import re
 
 from openai_cost_calculator.adapters.common import (
     MONEY,
@@ -25,11 +27,13 @@ def checkpoint_text(
     *,
     proxy_url: Optional[str] = None,
     session: Optional[str] = None,
+    on_error=None,
 ) -> Optional[str]:
     session_id = session or os.environ.get("OCC_SESSION") or "default"
     data = _post_json(
         _url(proxy_url, "/_occ/checkpoint", {"session": session_id}),
         timeout=1.0,
+        on_error=on_error,
     )
     if not data:
         return None
@@ -52,7 +56,10 @@ def notify_main() -> int:
         if not isinstance(notification, dict):
             return 0
         if notification.get("type") != "agent-turn-complete":
-            _run_previous_notify(raw_notification)
+            _run_previous_notify(
+                raw_notification,
+                on_error=_record_notifier_diagnostic,
+            )
             return 0
         settings = _codex_adapter_settings()
         session = (
@@ -64,14 +71,20 @@ def notify_main() -> int:
             notification,
             proxy_url=settings.get("proxy_url"),
             session=session,
+            on_error=_record_notifier_diagnostic,
         )
         if line:
             print(line)
         _run_previous_notify(
             raw_notification,
             previous_notify=settings.get("previous_notify"),
+            on_error=_record_notifier_diagnostic,
         )
-    except Exception:
+    except Exception as exc:
+        _record_notifier_diagnostic(
+            "notifier_failed",
+            f"notification handling failed: {type(exc).__name__}",
+        )
         return 0
     return 0
 
@@ -139,20 +152,31 @@ def _get_json(url: str, *, timeout: float) -> Optional[dict[str, Any]]:
     return _read_json(request, timeout=timeout)
 
 
-def _post_json(url: str, *, timeout: float) -> Optional[dict[str, Any]]:
+def _post_json(
+    url: str,
+    *,
+    timeout: float,
+    on_error=None,
+) -> Optional[dict[str, Any]]:
     request = urllib.request.Request(url, method="POST")
-    return _read_json(request, timeout=timeout)
+    return _read_json(request, timeout=timeout, on_error=on_error)
 
 
 def _read_json(
     request: urllib.request.Request,
     *,
     timeout: float,
+    on_error=None,
 ) -> Optional[dict[str, Any]]:
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             payload = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        if on_error is not None:
+            on_error(
+                "checkpoint_unavailable",
+                f"proxy checkpoint request failed: {type(exc).__name__}",
+            )
         return None
     return payload if isinstance(payload, dict) else None
 
@@ -241,6 +265,7 @@ def _run_previous_notify(
     notification: Optional[str],
     *,
     previous_notify: Optional[str] = None,
+    on_error=None,
 ) -> None:
     if not notification:
         return
@@ -251,13 +276,23 @@ def _run_previous_notify(
     if not command or _is_self_notify(command[0]):
         return
     try:
-        subprocess.run(
+        completed = subprocess.run(
             [*command, notification],
             check=False,
             timeout=5,
             stdin=subprocess.DEVNULL,
         )
-    except Exception:
+        if completed.returncode != 0 and on_error is not None:
+            on_error(
+                "previous_notifier_failed",
+                f"previous notifier exited with status {completed.returncode}",
+            )
+    except Exception as exc:
+        if on_error is not None:
+            on_error(
+                "previous_notifier_failed",
+                f"previous notifier could not run: {type(exc).__name__}",
+            )
         return
 
 
@@ -287,3 +322,57 @@ def _parse_notify_command(value: Optional[str]) -> Optional[list[str]]:
 
 def _is_self_notify(command: str) -> bool:
     return Path(command).name in {"occ-codex-notify", "occ-codex-statusline"}
+
+
+def notifier_diagnostics() -> list[dict[str, Any]]:
+    path = _notifier_diagnostic_path()
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    diagnostics = []
+    for line in lines[-100:]:
+        try:
+            payload = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(payload, dict):
+            diagnostics.append(payload)
+    return diagnostics
+
+
+def _record_notifier_diagnostic(code: str, message: str) -> None:
+    path = _notifier_diagnostic_path()
+    diagnostic = {
+        "code": _safe_diagnostic_text(code, 64),
+        "message": _safe_diagnostic_text(message, 500),
+        "timestamp": time.time(),
+    }
+    diagnostics = notifier_diagnostics()
+    diagnostics.append(diagnostic)
+    diagnostics = diagnostics[-100:]
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "".join(json.dumps(item, separators=(",", ":")) + "\n" for item in diagnostics),
+            encoding="utf-8",
+        )
+        path.chmod(0o600)
+    except OSError:
+        return
+
+
+def _notifier_diagnostic_path() -> Path:
+    return (
+        Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+        / "occ-notifier-diagnostics.jsonl"
+    )
+
+
+_SECRET_RE = re.compile(r"(?i)(?:bearer\s+)[^\s,;]+|(?:sk-[a-z0-9_-]{8,})")
+
+
+def _safe_diagnostic_text(value: object, limit: int) -> str:
+    text = str(value).replace("\r", " ").replace("\n", " ")
+    text = "".join(character if character.isprintable() else "?" for character in text)
+    return _SECRET_RE.sub("[REDACTED]", text)[:limit]

--- a/openai_cost_calculator/adapters/codex.py
+++ b/openai_cost_calculator/adapters/codex.py
@@ -148,7 +148,7 @@ def _url(
 
 
 def _get_json(url: str, *, timeout: float) -> Optional[dict[str, Any]]:
-    request = urllib.request.Request(url, method="GET")
+    request = urllib.request.Request(url, method="GET", headers=_admin_headers())
     return _read_json(request, timeout=timeout)
 
 
@@ -158,7 +158,7 @@ def _post_json(
     timeout: float,
     on_error=None,
 ) -> Optional[dict[str, Any]]:
-    request = urllib.request.Request(url, method="POST")
+    request = urllib.request.Request(url, method="POST", headers=_admin_headers())
     return _read_json(request, timeout=timeout, on_error=on_error)
 
 
@@ -376,3 +376,16 @@ def _safe_diagnostic_text(value: object, limit: int) -> str:
     text = str(value).replace("\r", " ").replace("\n", " ")
     text = "".join(character if character.isprintable() else "?" for character in text)
     return _SECRET_RE.sub("[REDACTED]", text)[:limit]
+
+
+def _admin_headers() -> dict[str, str]:
+    token = os.environ.get("OCC_ADMIN_TOKEN")
+    token_file = os.environ.get("OCC_ADMIN_TOKEN_FILE")
+    if token is None and token_file:
+        try:
+            token = Path(token_file).expanduser().read_text(encoding="utf-8").strip()
+        except OSError:
+            token = None
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -76,12 +76,15 @@ def uninstall_claude_code(scope: str = "user") -> list[str]:
 
 def install_codex(proxy_url: str, session: str) -> list[str]:
     path = _codex_config_path()
+    _refuse_symlink(path)
     text = _read_text(path)
     _validate_toml(text, path)
+    _validate_managed_blocks(text, path)
     previous_notify = _managed_previous_key(text, "notify")
     previous_model_provider = _managed_previous_key(text, "model_provider")
     previous_openai_base_url = _managed_previous_key(text, "openai_base_url")
     base = _remove_managed_block(text)
+    _refuse_conflicting_provider(base, path)
     if (
         previous_openai_base_url
         and _extract_top_level_key(base, "openai_base_url")[0] is None
@@ -112,8 +115,10 @@ def install_codex(proxy_url: str, session: str) -> list[str]:
 
 def uninstall_codex() -> list[str]:
     path = _codex_config_path()
+    _refuse_symlink(path)
     text = _read_text(path)
     _validate_toml(text, path)
+    _validate_managed_blocks(text, path)
     previous_notify = _managed_previous_key(text, "notify")
     previous_model_provider = _managed_previous_key(text, "model_provider")
     new_text = _remove_managed_block(text)
@@ -170,6 +175,7 @@ def _write_text(path: Path, text: str) -> None:
 
 
 def _atomic_write_text(path: Path, text: str) -> None:
+    _refuse_symlink(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     previous_mode = path.stat().st_mode & 0o777 if path.exists() else 0o600
     temporary_path: Optional[Path] = None
@@ -206,6 +212,49 @@ def _validate_toml(text: str, path: Path) -> None:
         raise ValueError(
             f"Refusing to modify invalid Codex configuration at {path}: {exc}"
         ) from exc
+
+
+def _validate_managed_blocks(text: str, path: Path) -> None:
+    depth = 0
+    blocks = 0
+    for line in text.splitlines():
+        marker = line.strip()
+        if marker == CODEX_BEGIN:
+            if depth:
+                raise ValueError(
+                    f"Refusing to modify malformed managed blocks at {path}: nested start marker"
+                )
+            depth = 1
+            blocks += 1
+        elif marker == CODEX_END:
+            if not depth:
+                raise ValueError(
+                    f"Refusing to modify malformed managed blocks at {path}: unmatched end marker"
+                )
+            depth = 0
+    if depth:
+        raise ValueError(
+            f"Refusing to modify malformed managed blocks at {path}: unmatched start marker"
+        )
+    if blocks not in {0, 2}:
+        raise ValueError(
+            f"Refusing to modify unexpected managed blocks at {path}: found {blocks}, expected 0 or 2"
+        )
+
+
+def _refuse_conflicting_provider(text: str, path: Path) -> None:
+    if "[model_providers.openai_cost_calculator]" in {
+        line.strip() for line in text.splitlines()
+    }:
+        raise ValueError(
+            "Refusing to overwrite existing Codex provider "
+            f"'openai_cost_calculator' at {path}"
+        )
+
+
+def _refuse_symlink(path: Path) -> None:
+    if path.is_symlink():
+        raise ValueError(f"Refusing to replace symlinked configuration at {path}")
 
 
 def _backup(path: Path) -> None:

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -73,7 +73,12 @@ def uninstall_claude_code(scope: str = "user") -> list[str]:
     return [f"{path}: removed {', '.join(changed)}"] if changed else [f"{path}: not installed"]
 
 
-def install_codex(proxy_url: str, session: str) -> list[str]:
+def install_codex(
+    proxy_url: str,
+    session: str,
+    *,
+    supports_websockets: bool = False,
+) -> list[str]:
     path = _codex_config_path()
     _refuse_symlink(path)
     text = _read_text(path)
@@ -124,6 +129,7 @@ def install_codex(proxy_url: str, session: str) -> list[str]:
         None
         if stashed_model_provider or extracted_model_provider
         else previous_model_provider,
+        supports_websockets=supports_websockets,
         trim_final_newline=trim_final_newline,
     )
     new_text = _insert_codex_blocks(base, top_block, provider_block)
@@ -348,6 +354,7 @@ def _codex_blocks(
     previous_notify: Optional[str] = None,
     previous_model_provider: Optional[str] = None,
     *,
+    supports_websockets: bool = False,
     trim_final_newline: bool = False,
 ) -> tuple[str, str]:
     escaped_proxy = proxy_url.replace("\\", "\\\\").replace('"', '\\"')
@@ -380,7 +387,7 @@ def _codex_blocks(
         f'base_url = "{escaped_api_base}"\n'
         "requires_openai_auth = true\n"
         'wire_api = "responses"\n'
-        "supports_websockets = true\n"
+        f"supports_websockets = {'true' if supports_websockets else 'false'}\n"
         f'http_headers = {{ "X-OCC-Session" = "{escaped_session}" }}\n'
         f"{CODEX_END}\n"
     )

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
 import tempfile
@@ -11,6 +12,8 @@ OCC_STATUSLINE = {"type": "command", "command": "occ-cc-statusline"}
 OCC_STOP_HOOK = {"type": "command", "command": "occ-cc-stop-hook", "timeout": 5}
 CODEX_BEGIN = "# >>> openai-cost-calculator"
 CODEX_END = "# <<< openai-cost-calculator"
+CODEX_RESTORE_PREFIX = "# occ-restore-"
+CODEX_TRIM_FINAL_NEWLINE = "# occ-trim-final-newline = true"
 
 
 def install_claude_code(scope: str = "user") -> list[str]:
@@ -86,15 +89,42 @@ def install_codex(proxy_url: str, session: str) -> list[str]:
         and _extract_top_level_key(base, "openai_base_url")[0] is None
     ):
         base = f"{previous_openai_base_url}\n{base.lstrip()}"
-    extracted_notify, base = _extract_top_level_key(base, "notify")
-    extracted_model_provider, base = _extract_top_level_key(base, "model_provider")
+    stashed_notify = _stashed_top_level_key(base, "notify")
+    stashed_model_provider = _stashed_top_level_key(base, "model_provider")
+    extracted_notify = None
+    extracted_model_provider = None
+    if stashed_notify is None:
+        extracted_notify, base = _stash_top_level_key(base, "notify")
+    if stashed_model_provider is None:
+        extracted_model_provider, base = _stash_top_level_key(base, "model_provider")
     previous_notify = previous_notify or extracted_notify
     previous_model_provider = previous_model_provider or extracted_model_provider
+    if stashed_notify is None and extracted_notify is None and previous_notify:
+        base = _prepend_stashed_key(base, "notify", previous_notify)
+        stashed_notify = previous_notify
+    if (
+        stashed_model_provider is None
+        and extracted_model_provider is None
+        and previous_model_provider
+    ):
+        base = _prepend_stashed_key(
+            base,
+            "model_provider",
+            previous_model_provider,
+        )
+        stashed_model_provider = previous_model_provider
+    _top_level, sections = _split_first_section(base)
+    trim_final_newline = bool(
+        base and not sections and not base.endswith(("\n", "\r"))
+    )
     top_block, provider_block = _codex_blocks(
         proxy_url,
         session,
-        previous_notify,
-        previous_model_provider,
+        None if stashed_notify or extracted_notify else previous_notify,
+        None
+        if stashed_model_provider or extracted_model_provider
+        else previous_model_provider,
+        trim_final_newline=trim_final_newline,
     )
     new_text = _insert_codex_blocks(base, top_block, provider_block)
     if new_text != text:
@@ -117,9 +147,22 @@ def uninstall_codex() -> list[str]:
     previous_notify = _managed_previous_key(text, "notify")
     previous_model_provider = _managed_previous_key(text, "model_provider")
     new_text = _remove_managed_block(text)
-    if previous_notify and _extract_top_level_key(new_text, "notify")[0] is None:
+    restored_notify, new_text = _restore_stashed_key(new_text, "notify")
+    restored_model_provider, new_text = _restore_stashed_key(
+        new_text,
+        "model_provider",
+    )
+    if (
+        not restored_notify
+        and previous_notify
+        and _extract_top_level_key(new_text, "notify")[0] is None
+    ):
         new_text = f"{previous_notify}\n{new_text.lstrip()}"
-    if previous_model_provider and _extract_top_level_key(new_text, "model_provider")[0] is None:
+    if (
+        not restored_model_provider
+        and previous_model_provider
+        and _extract_top_level_key(new_text, "model_provider")[0] is None
+    ):
         insert = previous_model_provider
         if not insert.endswith("\n"):
             insert = f"{insert}\n"
@@ -159,7 +202,8 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 def _read_text(path: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8")
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            return handle.read()
     except FileNotFoundError:
         return ""
 
@@ -177,6 +221,7 @@ def _atomic_write_text(path: Path, text: str) -> None:
         with tempfile.NamedTemporaryFile(
             mode="w",
             encoding="utf-8",
+            newline="",
             dir=path.parent,
             prefix=f".{path.name}.",
             suffix=".tmp",
@@ -302,6 +347,8 @@ def _codex_blocks(
     session: str,
     previous_notify: Optional[str] = None,
     previous_model_provider: Optional[str] = None,
+    *,
+    trim_final_newline: bool = False,
 ) -> tuple[str, str]:
     escaped_proxy = proxy_url.replace("\\", "\\\\").replace('"', '\\"')
     api_base = _proxy_api_base(proxy_url)
@@ -312,6 +359,8 @@ def _codex_blocks(
         previous += f"# previous_notify = {previous_notify}\n"
     if previous_model_provider:
         previous += f"# previous_model_provider = {previous_model_provider}\n"
+    if trim_final_newline:
+        previous += f"{CODEX_TRIM_FINAL_NEWLINE}\n"
     top_block = (
         f"{CODEX_BEGIN}\n"
         "# OpenAI Cost Calculator routes Codex through the local proxy\n"
@@ -346,25 +395,21 @@ def _prepend_managed_block(text: str, block: str) -> str:
 
 
 def _insert_codex_blocks(text: str, top_block: str, provider_block: str) -> str:
-    base = _remove_managed_block(text).strip()
+    base = _remove_managed_block(text)
     if not base:
-        return f"{top_block}\n{provider_block}"
+        return f"{top_block}{provider_block}"
     top_level, sections = _split_first_section(base)
-    top_level = top_level.strip()
-    sections = sections.strip()
-    parts = [top_block.rstrip()]
-    if top_level:
-        parts.append(top_level)
-    parts.append(provider_block.rstrip())
     if sections:
-        parts.append(sections)
-    return "\n\n".join(parts) + "\n"
+        return f"{top_block}{top_level}{provider_block}{sections}"
+    separator = "" if base.endswith(("\n", "\r")) else "\n"
+    return f"{top_block}{base}{separator}{provider_block}"
 
 
 def _remove_managed_block(text: str) -> str:
     lines = text.splitlines(keepends=True)
     output: list[str] = []
     in_block = False
+    trim_final_newline = False
     for line in lines:
         if line.strip() == CODEX_BEGIN:
             in_block = True
@@ -372,9 +417,14 @@ def _remove_managed_block(text: str) -> str:
         if line.strip() == CODEX_END:
             in_block = False
             continue
+        if in_block and line.strip() == CODEX_TRIM_FINAL_NEWLINE:
+            trim_final_newline = True
         if not in_block:
             output.append(line)
-    return "".join(output).rstrip() + ("\n" if output else "")
+    result = "".join(output)
+    if trim_final_newline and result.endswith("\n"):
+        result = result[:-1]
+    return result
 
 
 def _managed_previous_key(text: str, key: str) -> Optional[str]:
@@ -410,6 +460,77 @@ def _extract_top_level_key(text: str, key: str) -> Tuple[Optional[str], str]:
             continue
         output.append(line)
     return found, "".join(output)
+
+
+def _stash_top_level_key(text: str, key: str) -> Tuple[Optional[str], str]:
+    section: Optional[str] = None
+    found: Optional[str] = None
+    output: list[str] = []
+    prefix = f"{key} "
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped
+        if (
+            section is None
+            and found is None
+            and (stripped.startswith(f"{key}=") or stripped.startswith(prefix))
+        ):
+            found = stripped
+            output.append(_stashed_line(key, line))
+            continue
+        output.append(line)
+    return found, "".join(output)
+
+
+def _prepend_stashed_key(text: str, key: str, assignment: str) -> str:
+    raw_line = assignment if assignment.endswith(("\n", "\r")) else f"{assignment}\n"
+    return f"{_stashed_line(key, raw_line)}{text}"
+
+
+def _stashed_line(key: str, raw_line: str) -> str:
+    if raw_line.endswith("\r\n"):
+        ending = "\r\n"
+    elif raw_line.endswith(("\n", "\r")):
+        ending = raw_line[-1]
+    else:
+        ending = ""
+    encoded = base64.urlsafe_b64encode(raw_line.encode("utf-8")).decode("ascii")
+    return f"{CODEX_RESTORE_PREFIX}{key} = {encoded}{ending}"
+
+
+def _stashed_top_level_key(text: str, key: str) -> Optional[str]:
+    marker = f"{CODEX_RESTORE_PREFIX}{key} = "
+    matches = [line for line in text.splitlines() if line.startswith(marker)]
+    if len(matches) > 1:
+        raise ValueError(f"Refusing duplicate restoration placeholders for {key}")
+    if not matches:
+        return None
+    raw = _decode_stashed_line(matches[0], marker)
+    return raw.strip()
+
+
+def _restore_stashed_key(text: str, key: str) -> Tuple[bool, str]:
+    marker = f"{CODEX_RESTORE_PREFIX}{key} = "
+    restored = False
+    output: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if line.startswith(marker):
+            if restored:
+                raise ValueError(f"Refusing duplicate restoration placeholders for {key}")
+            output.append(_decode_stashed_line(line.rstrip("\r\n"), marker))
+            restored = True
+        else:
+            output.append(line)
+    return restored, "".join(output)
+
+
+def _decode_stashed_line(line: str, marker: str) -> str:
+    encoded = line.removeprefix(marker).strip()
+    try:
+        return base64.b64decode(encoded, altchars=b"-_", validate=True).decode("utf-8")
+    except Exception as exc:
+        raise ValueError("Refusing malformed Codex restoration placeholder") from exc
 
 
 def _split_first_section(text: str) -> tuple[str, str]:

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import tempfile
-import time
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
@@ -40,7 +38,6 @@ def install_claude_code(scope: str = "user") -> list[str]:
         changed.append("Stop hook")
 
     if changed:
-        _backup(path)
         _write_json(path, settings)
     return [f"{path}: installed {', '.join(dict.fromkeys(changed))}"] if changed else [f"{path}: already installed"]
 
@@ -69,7 +66,6 @@ def uninstall_claude_code(scope: str = "user") -> list[str]:
             settings.pop("hooks", None)
 
     if changed:
-        _backup(path)
         _write_json(path, settings)
     return [f"{path}: removed {', '.join(changed)}"] if changed else [f"{path}: not installed"]
 
@@ -102,7 +98,6 @@ def install_codex(proxy_url: str, session: str) -> list[str]:
     )
     new_text = _insert_codex_blocks(base, top_block, provider_block)
     if new_text != text:
-        _backup(path)
         _write_text(path, new_text)
         return [
             f"{path}: installed Codex cost adapter block",
@@ -130,7 +125,6 @@ def uninstall_codex() -> list[str]:
             insert = f"{insert}\n"
         new_text = f"{insert}{new_text.lstrip()}"
     if new_text != text:
-        _backup(path)
         _write_text(path, new_text)
         return [f"{path}: removed openai-cost-calculator block"]
     return [f"{path}: not installed"]
@@ -194,6 +188,7 @@ def _atomic_write_text(path: Path, text: str) -> None:
             os.fsync(handle.fileno())
         temporary_path.chmod(previous_mode)
         os.replace(temporary_path, path)
+        _fsync_directory(path.parent)
     finally:
         if temporary_path is not None:
             temporary_path.unlink(missing_ok=True)
@@ -257,15 +252,15 @@ def _refuse_symlink(path: Path) -> None:
         raise ValueError(f"Refusing to replace symlinked configuration at {path}")
 
 
-def _backup(path: Path) -> None:
-    if not path.exists():
-        return
-    stamp = time.strftime("%Y%m%d%H%M%S")
-    backup = path.with_name(f"{path.name}.occ-backup-{stamp}")
+def _fsync_directory(path: Path) -> None:
     try:
-        shutil.copy2(path, backup)
-    except Exception:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
         return
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _has_hook(entries: list[Any], command: str) -> bool:

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -103,10 +103,8 @@ def install_codex(proxy_url: str, session: str) -> list[str]:
         _write_text(path, new_text)
         return [
             f"{path}: installed Codex cost adapter block",
-            f"API-key login proxy: openai-cost-calculator proxy --port {_proxy_port(proxy_url)}",
-            "ChatGPT login proxy: openai-cost-calculator proxy "
-            f"--port {_proxy_port(proxy_url)} "
-            "--upstream https://chatgpt.com/backend-api/codex",
+            "Start the matching proxy: openai-cost-calculator proxy "
+            f"--port {_proxy_port(proxy_url)} --auth-mode auto",
             "Ensure Codex is logged in with ChatGPT or an OpenAI API key.",
         ]
     return [f"{path}: already installed"]

--- a/openai_cost_calculator/adapters/install.py
+++ b/openai_cost_calculator/adapters/install.py
@@ -331,7 +331,7 @@ def _codex_blocks(
         f'base_url = "{escaped_api_base}"\n'
         "requires_openai_auth = true\n"
         'wire_api = "responses"\n'
-        "supports_websockets = false\n"
+        "supports_websockets = true\n"
         f'http_headers = {{ "X-OCC-Session" = "{escaped_session}" }}\n'
         f"{CODEX_END}\n"
     )

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
 from typing import Optional, Sequence
+import urllib.error
+import urllib.parse
+import urllib.request
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -11,7 +19,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     proxy_parser = subparsers.add_parser("proxy", help="Run the local cost proxy")
     proxy_parser.add_argument("--host", default="127.0.0.1")
     proxy_parser.add_argument("--port", default=8100, type=int)
-    proxy_parser.add_argument("--upstream", default="https://api.openai.com/v1")
+    proxy_parser.add_argument("--upstream")
+    proxy_parser.add_argument(
+        "--auth-mode",
+        choices=["auto", "api-key", "chatgpt"],
+        default="auto",
+        help="Select the matching OpenAI authentication domain (default: auto)",
+    )
+    proxy_parser.add_argument(
+        "--ledger",
+        help="Persist accounting to this JSON file (single proxy process only)",
+    )
 
     install_parser = subparsers.add_parser("install", help="Install agent UI adapters")
     install_subparsers = install_parser.add_subparsers(dest="target", required=True)
@@ -27,19 +45,86 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     claude_uninstall.add_argument("--scope", choices=["user", "project"], default="user")
     uninstall_subparsers.add_parser("codex")
 
+    status_parser = subparsers.add_parser(
+        "status", help="Inspect proxy totals, latest calls, and diagnostics"
+    )
+    _add_proxy_client_arguments(status_parser)
+    status_parser.add_argument("--json", action="store_true")
+    status_parser.add_argument(
+        "--diagnostics", action="store_true", help="Show accounting diagnostics"
+    )
+
+    checkpoint_parser = subparsers.add_parser(
+        "checkpoint", help="Consume and print the next session checkpoint"
+    )
+    _add_proxy_client_arguments(checkpoint_parser)
+    checkpoint_parser.add_argument("--json", action="store_true")
+
+    reset_parser = subparsers.add_parser("reset", help="Reset proxy accounting state")
+    reset_parser.add_argument("--proxy-url", default=_default_proxy_url())
+    reset_parser.add_argument("--yes", action="store_true", help="Confirm destructive reset")
+
+    ledger_parser = subparsers.add_parser(
+        "ledger", help="Inspect or reset an offline durable ledger"
+    )
+    ledger_subparsers = ledger_parser.add_subparsers(dest="ledger_command", required=True)
+    ledger_inspect = ledger_subparsers.add_parser("inspect")
+    ledger_inspect.add_argument("path")
+    ledger_inspect.add_argument("--json", action="store_true")
+    ledger_reset = ledger_subparsers.add_parser("reset")
+    ledger_reset.add_argument("path")
+    ledger_reset.add_argument("--yes", action="store_true")
+
+    pricing_parser = subparsers.add_parser("pricing", help="Pricing data operations")
+    pricing_subparsers = pricing_parser.add_subparsers(dest="pricing_command", required=True)
+    pricing_validate = pricing_subparsers.add_parser("validate")
+    pricing_validate.add_argument(
+        "--file",
+        default=str(Path(__file__).resolve().parents[1] / "data" / "gpt_pricing_data.csv"),
+    )
+
+    subparsers.add_parser(
+        "self-test-codex", help="Run the opt-in isolated real Codex self-test"
+    )
+
     args = parser.parse_args(argv)
     if args.command == "proxy":
-        return _run_proxy(args.host, args.port, args.upstream)
+        return _run_proxy(
+            args.host,
+            args.port,
+            args.upstream,
+            auth_mode=args.auth_mode,
+            ledger=args.ledger,
+        )
     if args.command == "install":
         return _install(args)
     if args.command == "uninstall":
         return _uninstall(args)
+    if args.command == "status":
+        return _status(args)
+    if args.command == "checkpoint":
+        return _checkpoint(args)
+    if args.command == "reset":
+        return _reset(args)
+    if args.command == "ledger":
+        return _ledger(args)
+    if args.command == "pricing":
+        return _pricing(args)
+    if args.command == "self-test-codex":
+        return _self_test_codex()
 
     parser.error(f"unknown command: {args.command}")
     return 2
 
 
-def _run_proxy(host: str, port: int, upstream: str) -> int:
+def _run_proxy(
+    host: str,
+    port: int,
+    upstream: Optional[str],
+    *,
+    auth_mode: str,
+    ledger: Optional[str],
+) -> int:
     try:
         import uvicorn
     except ImportError as exc:
@@ -49,11 +134,27 @@ def _run_proxy(host: str, port: int, upstream: str) -> int:
         ) from exc
 
     from openai_cost_calculator.proxy.app import create_app
+    from openai_cost_calculator.proxy.upstreams import (
+        UpstreamSelectionError,
+        resolve_upstream,
+    )
 
-    app = create_app(upstream=upstream)
+    try:
+        selection = resolve_upstream(auth_mode=auth_mode, upstream=upstream)
+        app = create_app(upstream_selection=selection, ledger_path=ledger)
+    except (UpstreamSelectionError, OSError, RuntimeError, ValueError) as exc:
+        print(f"proxy configuration error: {exc}", file=sys.stderr)
+        return 2
     base = f"http://{host}:{port}"
     print(f"OpenAI-compatible base_url: {base}/v1")
     print(f"Cost summary: {base}/_occ/costs")
+    print(
+        "Routing: "
+        f"auth={selection.auth_mode}, upstream={selection.category}, "
+        f"override={'yes' if selection.explicit_override else 'no'}"
+    )
+    if ledger:
+        print(f"Durable ledger: {Path(ledger).expanduser()}")
     uvicorn.run(app, host=host, port=port)
     return 0
 
@@ -91,6 +192,204 @@ def _uninstall(args: argparse.Namespace) -> int:
     for message in messages:
         print(message)
     return 0
+
+
+def _add_proxy_client_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--proxy-url", default=_default_proxy_url())
+    parser.add_argument("--session")
+
+
+def _default_proxy_url() -> str:
+    return os.environ.get("OCC_PROXY_URL", "http://127.0.0.1:8100")
+
+
+def _status(args: argparse.Namespace) -> int:
+    from openai_cost_calculator.adapters.codex import notifier_diagnostics
+
+    local_diagnostics = notifier_diagnostics()
+    query = {"session": args.session} if args.session else None
+    try:
+        costs = _request_json(args.proxy_url, "/_occ/costs", query=query)
+        health = _request_json(args.proxy_url, "/_occ/health")
+    except RuntimeError as exc:
+        print(f"status unavailable: {exc}", file=sys.stderr)
+        if args.diagnostics and local_diagnostics:
+            _print_notifier_diagnostics(local_diagnostics)
+        return 1
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "costs": costs,
+                    "health": health,
+                    "notifier_diagnostics": local_diagnostics,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    _print_summary(costs, include_diagnostics=args.diagnostics)
+    routing = health.get("routing", {})
+    persistence = health.get("persistence", {})
+    print(
+        "Routing: "
+        f"auth={routing.get('auth_mode', 'unknown')}, "
+        f"upstream={routing.get('upstream_category', 'unknown')}, "
+        f"override={'yes' if routing.get('explicit_override') else 'no'}"
+    )
+    if persistence.get("enabled"):
+        state = "healthy" if persistence.get("healthy") else "ERROR"
+        print(f"Persistence: {state} ({persistence.get('path')})")
+    else:
+        print("Persistence: disabled (in-memory only)")
+    if args.diagnostics:
+        _print_notifier_diagnostics(local_diagnostics)
+    return 0
+
+
+def _checkpoint(args: argparse.Namespace) -> int:
+    query = {"session": args.session} if args.session else None
+    try:
+        payload = _request_json(
+            args.proxy_url,
+            "/_occ/checkpoint",
+            method="POST",
+            query=query,
+        )
+    except RuntimeError as exc:
+        print(f"checkpoint failed: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(
+            f"{payload.get('session', 'default')}: "
+            f"{payload.get('num_calls', 0)} calls, "
+            f"${payload.get('total_cost', '0.00000000')}"
+        )
+    return 0
+
+
+def _reset(args: argparse.Namespace) -> int:
+    if not args.yes:
+        print("refusing to reset accounting without --yes", file=sys.stderr)
+        return 2
+    try:
+        _request_json(args.proxy_url, "/_occ/reset", method="POST")
+    except RuntimeError as exc:
+        print(f"reset failed: {exc}", file=sys.stderr)
+        return 1
+    print("Proxy accounting reset.")
+    return 0
+
+
+def _ledger(args: argparse.Namespace) -> int:
+    from openai_cost_calculator.proxy.ledger import LedgerError
+    from openai_cost_calculator.proxy.registry import TrackerRegistry
+
+    try:
+        registry = TrackerRegistry(ledger_path=args.path)
+    except LedgerError as exc:
+        print(f"ledger unavailable: {exc}", file=sys.stderr)
+        return 1
+    try:
+        if args.ledger_command == "inspect":
+            summary = registry.summary()
+            if args.json:
+                print(json.dumps(summary, indent=2, sort_keys=True))
+            else:
+                _print_summary(summary, include_diagnostics=True)
+            return 0
+        if not args.yes:
+            print("refusing to reset the ledger without --yes", file=sys.stderr)
+            return 2
+        registry.reset()
+        print(f"Durable ledger reset: {Path(args.path).expanduser()}")
+        return 0
+    except LedgerError as exc:
+        print(f"ledger operation failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        registry.close()
+
+
+def _pricing(args: argparse.Namespace) -> int:
+    from openai_cost_calculator.pricing import validate_pricing_file
+
+    try:
+        count = validate_pricing_file(args.file)
+    except (OSError, ValueError) as exc:
+        print(f"pricing validation failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Pricing data valid: {count} model/date entries in {args.file}")
+    return 0
+
+
+def _self_test_codex() -> int:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "self_test_codex_integration.py"
+    return subprocess.run([sys.executable, str(script)], check=False).returncode
+
+
+def _request_json(
+    proxy_url: str,
+    path: str,
+    *,
+    method: str = "GET",
+    query: Optional[dict[str, str]] = None,
+) -> dict:
+    url = f"{proxy_url.rstrip('/')}{path}"
+    if query:
+        url = f"{url}?{urllib.parse.urlencode(query)}"
+    request = urllib.request.Request(url, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = json.loads(exc.read().decode("utf-8"))
+        except Exception:
+            detail = {"status": exc.code}
+        raise RuntimeError(f"HTTP {exc.code}: {detail}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        raise RuntimeError(str(exc)) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("proxy returned a non-object JSON response")
+    return payload
+
+
+def _print_summary(payload: dict, *, include_diagnostics: bool) -> None:
+    sessions = payload.get("sessions", {})
+    if not isinstance(sessions, dict) or not sessions:
+        print("No accounting sessions recorded.")
+        return
+    for session_id, session in sessions.items():
+        if not isinstance(session, dict):
+            continue
+        latest = session.get("latest_call")
+        latest_text = "none"
+        if isinstance(latest, dict):
+            latest_text = (
+                f"{latest.get('model', 'unknown')} "
+                f"${latest.get('cost', {}).get('total_cost', 'unknown')}"
+            )
+        print(
+            f"{session_id}: total ${session.get('session_total', '0.00000000')} "
+            f"(historical ${session.get('historical_total', '0.00000000')}, "
+            f"process ${session.get('process_total', '0.00000000')}), latest {latest_text}"
+        )
+        if include_diagnostics:
+            for error in session.get("errors", []):
+                if isinstance(error, dict):
+                    print(f"  diagnostic {error.get('code')}: {error.get('message')}")
+
+
+def _print_notifier_diagnostics(diagnostics: list[dict]) -> None:
+    for diagnostic in diagnostics:
+        print(
+            "Notifier diagnostic "
+            f"{diagnostic.get('code')}: {diagnostic.get('message')}"
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import os
 from pathlib import Path
+import stat
 import sys
 from typing import Optional, Sequence
 import urllib.error
@@ -32,6 +34,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     proxy_parser.add_argument(
         "--database",
         help="Persist accounting to a concurrent SQLite database (recommended)",
+    )
+    proxy_parser.add_argument(
+        "--allow-remote",
+        action="store_true",
+        help="Permit a non-loopback bind; requires an administrative token",
+    )
+    proxy_parser.add_argument(
+        "--admin-token-file",
+        help="Read the administrative bearer token from a protected file",
     )
 
     install_parser = subparsers.add_parser("install", help="Install agent UI adapters")
@@ -65,6 +76,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     reset_parser = subparsers.add_parser("reset", help="Reset proxy accounting state")
     reset_parser.add_argument("--proxy-url", default=_default_proxy_url())
+    reset_parser.add_argument("--admin-token-file")
     reset_parser.add_argument("--yes", action="store_true", help="Confirm destructive reset")
 
     ledger_parser = subparsers.add_parser(
@@ -108,6 +120,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             auth_mode=args.auth_mode,
             ledger=args.ledger,
             database=args.database,
+            allow_remote=args.allow_remote,
+            admin_token_file=args.admin_token_file,
         )
     if args.command == "install":
         return _install(args)
@@ -138,6 +152,8 @@ def _run_proxy(
     auth_mode: str,
     ledger: Optional[str],
     database: Optional[str],
+    allow_remote: bool,
+    admin_token_file: Optional[str],
 ) -> int:
     try:
         import uvicorn
@@ -156,11 +172,14 @@ def _run_proxy(
     try:
         if ledger and database:
             raise ValueError("pass either --ledger or --database, not both")
+        admin_token = _load_admin_token(admin_token_file)
+        _validate_proxy_exposure(host, allow_remote, admin_token)
         selection = resolve_upstream(auth_mode=auth_mode, upstream=upstream)
         app = create_app(
             upstream_selection=selection,
             ledger_path=ledger,
             database_path=database,
+            admin_token=admin_token,
         )
     except (UpstreamSelectionError, OSError, RuntimeError, ValueError) as exc:
         print(f"proxy configuration error: {exc}", file=sys.stderr)
@@ -173,6 +192,11 @@ def _run_proxy(
         f"auth={selection.auth_mode}, upstream={selection.category}, "
         f"override={'yes' if selection.explicit_override else 'no'}"
     )
+    if not _is_loopback_host(host):
+        print(
+            "WARNING: proxy is remotely reachable; protect it with TLS and trusted network controls",
+            file=sys.stderr,
+        )
     if ledger:
         print(f"Durable ledger: {Path(ledger).expanduser()}")
     if database:
@@ -219,6 +243,7 @@ def _uninstall(args: argparse.Namespace) -> int:
 def _add_proxy_client_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--proxy-url", default=_default_proxy_url())
     parser.add_argument("--session")
+    parser.add_argument("--admin-token-file")
 
 
 def _default_proxy_url() -> str:
@@ -231,9 +256,19 @@ def _status(args: argparse.Namespace) -> int:
     local_diagnostics = notifier_diagnostics()
     query = {"session": args.session} if args.session else None
     try:
-        costs = _request_json(args.proxy_url, "/_occ/costs", query=query)
-        health = _request_json(args.proxy_url, "/_occ/health")
-    except RuntimeError as exc:
+        admin_token = _load_admin_token(args.admin_token_file)
+        costs = _request_json(
+            args.proxy_url,
+            "/_occ/costs",
+            query=query,
+            admin_token=admin_token,
+        )
+        health = _request_json(
+            args.proxy_url,
+            "/_occ/health",
+            admin_token=admin_token,
+        )
+    except (RuntimeError, ValueError) as exc:
         print(f"status unavailable: {exc}", file=sys.stderr)
         if args.diagnostics and local_diagnostics:
             _print_notifier_diagnostics(local_diagnostics)
@@ -273,13 +308,15 @@ def _status(args: argparse.Namespace) -> int:
 def _checkpoint(args: argparse.Namespace) -> int:
     query = {"session": args.session} if args.session else None
     try:
+        admin_token = _load_admin_token(args.admin_token_file)
         payload = _request_json(
             args.proxy_url,
             "/_occ/checkpoint",
             method="POST",
             query=query,
+            admin_token=admin_token,
         )
-    except RuntimeError as exc:
+    except (RuntimeError, ValueError) as exc:
         print(f"checkpoint failed: {exc}", file=sys.stderr)
         return 1
     if args.json:
@@ -298,8 +335,14 @@ def _reset(args: argparse.Namespace) -> int:
         print("refusing to reset accounting without --yes", file=sys.stderr)
         return 2
     try:
-        _request_json(args.proxy_url, "/_occ/reset", method="POST")
-    except RuntimeError as exc:
+        admin_token = _load_admin_token(args.admin_token_file)
+        _request_json(
+            args.proxy_url,
+            "/_occ/reset",
+            method="POST",
+            admin_token=admin_token,
+        )
+    except (RuntimeError, ValueError) as exc:
         print(f"reset failed: {exc}", file=sys.stderr)
         return 1
     print("Proxy accounting reset.")
@@ -384,11 +427,17 @@ def _request_json(
     *,
     method: str = "GET",
     query: Optional[dict[str, str]] = None,
+    admin_token: Optional[str] = None,
 ) -> dict:
     url = f"{proxy_url.rstrip('/')}{path}"
     if query:
         url = f"{url}?{urllib.parse.urlencode(query)}"
-    request = urllib.request.Request(url, method=method)
+    headers = (
+        {"Authorization": f"Bearer {admin_token}"}
+        if admin_token is not None
+        else {}
+    )
+    request = urllib.request.Request(url, method=method, headers=headers)
     try:
         with urllib.request.urlopen(request, timeout=2) as response:
             payload = json.loads(response.read().decode("utf-8"))
@@ -403,6 +452,62 @@ def _request_json(
     if not isinstance(payload, dict):
         raise RuntimeError("proxy returned a non-object JSON response")
     return payload
+
+
+def _load_admin_token(path: Optional[str]) -> Optional[str]:
+    environment_token = os.environ.get("OCC_ADMIN_TOKEN")
+    environment_file = os.environ.get("OCC_ADMIN_TOKEN_FILE")
+    selected_path = path or environment_file
+    if path and environment_file and Path(path).expanduser() != Path(environment_file).expanduser():
+        raise ValueError(
+            "administrative token file is ambiguous between CLI and environment"
+        )
+    if selected_path and environment_token:
+        raise ValueError(
+            "set either OCC_ADMIN_TOKEN or an administrative token file, not both"
+        )
+    if selected_path:
+        token_path = Path(selected_path).expanduser()
+        try:
+            mode = stat.S_IMODE(token_path.stat().st_mode)
+            if mode & 0o077:
+                raise ValueError(
+                    "administrative token file must not be accessible by group or others"
+                )
+            token = token_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            raise ValueError("cannot read administrative token file") from exc
+    else:
+        token = environment_token
+    if token is not None and len(token) < 32:
+        raise ValueError("administrative token must contain at least 32 characters")
+    return token
+
+
+def _validate_proxy_exposure(
+    host: str,
+    allow_remote: bool,
+    admin_token: Optional[str],
+) -> None:
+    if _is_loopback_host(host):
+        return
+    if not allow_remote:
+        raise ValueError(
+            "non-loopback proxy binding requires explicit --allow-remote"
+        )
+    if admin_token is None:
+        raise ValueError(
+            "non-loopback proxy binding requires OCC_ADMIN_TOKEN or --admin-token-file"
+        )
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _print_summary(payload: dict, *, include_diagnostics: bool) -> None:

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -52,6 +52,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     codex_install = install_subparsers.add_parser("codex")
     codex_install.add_argument("--proxy-url", default="http://127.0.0.1:8100")
     codex_install.add_argument("--session", default="default")
+    codex_install.add_argument(
+        "--websockets",
+        action="store_true",
+        help="Opt in to Codex Responses WebSockets (HTTP is the cost-safe default)",
+    )
 
     uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall agent UI adapters")
     uninstall_subparsers = uninstall_parser.add_subparsers(dest="target", required=True)
@@ -214,7 +219,11 @@ def _install(args: argparse.Namespace) -> int:
     if args.target == "claude-code":
         messages = install_claude_code(args.scope)
     elif args.target == "codex":
-        messages = install_codex(args.proxy_url, args.session)
+        messages = install_codex(
+            args.proxy_url,
+            args.session,
+            supports_websockets=args.websockets,
+        )
     else:
         raise AssertionError(args.target)
     for message in messages:

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -4,7 +4,6 @@ import argparse
 import json
 import os
 from pathlib import Path
-import subprocess
 import sys
 from typing import Optional, Sequence
 import urllib.error
@@ -83,10 +82,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         default=str(Path(__file__).resolve().parents[1] / "data" / "gpt_pricing_data.csv"),
     )
 
-    subparsers.add_parser(
-        "self-test-codex", help="Run the opt-in isolated real Codex self-test"
-    )
-
     args = parser.parse_args(argv)
     if args.command == "proxy":
         return _run_proxy(
@@ -110,8 +105,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return _ledger(args)
     if args.command == "pricing":
         return _pricing(args)
-    if args.command == "self-test-codex":
-        return _self_test_codex()
 
     parser.error(f"unknown command: {args.command}")
     return 2
@@ -324,11 +317,6 @@ def _pricing(args: argparse.Namespace) -> int:
         return 1
     print(f"Pricing data valid: {count} model/date entries in {args.file}")
     return 0
-
-
-def _self_test_codex() -> int:
-    script = Path(__file__).resolve().parents[1] / "scripts" / "self_test_codex_integration.py"
-    return subprocess.run([sys.executable, str(script)], check=False).returncode
 
 
 def _request_json(

--- a/openai_cost_calculator/cli.py
+++ b/openai_cost_calculator/cli.py
@@ -27,7 +27,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     proxy_parser.add_argument(
         "--ledger",
-        help="Persist accounting to this JSON file (single proxy process only)",
+        help="Persist accounting to a legacy JSON file (single proxy process only)",
+    )
+    proxy_parser.add_argument(
+        "--database",
+        help="Persist accounting to a concurrent SQLite database (recommended)",
     )
 
     install_parser = subparsers.add_parser("install", help="Install agent UI adapters")
@@ -74,6 +78,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     ledger_reset.add_argument("path")
     ledger_reset.add_argument("--yes", action="store_true")
 
+    database_parser = subparsers.add_parser(
+        "database", help="Inspect or reset a SQLite accounting database"
+    )
+    database_subparsers = database_parser.add_subparsers(
+        dest="database_command", required=True
+    )
+    database_inspect = database_subparsers.add_parser("inspect")
+    database_inspect.add_argument("path")
+    database_inspect.add_argument("--json", action="store_true")
+    database_reset = database_subparsers.add_parser("reset")
+    database_reset.add_argument("path")
+    database_reset.add_argument("--yes", action="store_true")
+
     pricing_parser = subparsers.add_parser("pricing", help="Pricing data operations")
     pricing_subparsers = pricing_parser.add_subparsers(dest="pricing_command", required=True)
     pricing_validate = pricing_subparsers.add_parser("validate")
@@ -90,6 +107,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             args.upstream,
             auth_mode=args.auth_mode,
             ledger=args.ledger,
+            database=args.database,
         )
     if args.command == "install":
         return _install(args)
@@ -103,6 +121,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return _reset(args)
     if args.command == "ledger":
         return _ledger(args)
+    if args.command == "database":
+        return _database(args)
     if args.command == "pricing":
         return _pricing(args)
 
@@ -117,6 +137,7 @@ def _run_proxy(
     *,
     auth_mode: str,
     ledger: Optional[str],
+    database: Optional[str],
 ) -> int:
     try:
         import uvicorn
@@ -133,8 +154,14 @@ def _run_proxy(
     )
 
     try:
+        if ledger and database:
+            raise ValueError("pass either --ledger or --database, not both")
         selection = resolve_upstream(auth_mode=auth_mode, upstream=upstream)
-        app = create_app(upstream_selection=selection, ledger_path=ledger)
+        app = create_app(
+            upstream_selection=selection,
+            ledger_path=ledger,
+            database_path=database,
+        )
     except (UpstreamSelectionError, OSError, RuntimeError, ValueError) as exc:
         print(f"proxy configuration error: {exc}", file=sys.stderr)
         return 2
@@ -148,6 +175,8 @@ def _run_proxy(
     )
     if ledger:
         print(f"Durable ledger: {Path(ledger).expanduser()}")
+    if database:
+        print(f"SQLite database: {Path(database).expanduser()}")
     uvicorn.run(app, host=host, port=port)
     return 0
 
@@ -302,6 +331,36 @@ def _ledger(args: argparse.Namespace) -> int:
         return 0
     except LedgerError as exc:
         print(f"ledger operation failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        registry.close()
+
+
+def _database(args: argparse.Namespace) -> int:
+    from openai_cost_calculator.proxy.ledger import LedgerError
+    from openai_cost_calculator.proxy.registry import TrackerRegistry
+
+    try:
+        registry = TrackerRegistry(database_path=args.path)
+    except LedgerError as exc:
+        print(f"database unavailable: {exc}", file=sys.stderr)
+        return 1
+    try:
+        if args.database_command == "inspect":
+            summary = registry.summary()
+            if args.json:
+                print(json.dumps(summary, indent=2, sort_keys=True))
+            else:
+                _print_summary(summary, include_diagnostics=True)
+            return 0
+        if not args.yes:
+            print("refusing to reset the database without --yes", file=sys.stderr)
+            return 2
+        registry.reset()
+        print(f"SQLite accounting database reset: {Path(args.path).expanduser()}")
+        return 0
+    except LedgerError as exc:
+        print(f"database operation failed: {exc}", file=sys.stderr)
         return 1
     finally:
         registry.close()

--- a/openai_cost_calculator/core.py
+++ b/openai_cost_calculator/core.py
@@ -3,7 +3,7 @@ Pure cost arithmetic – no OpenAI–specific code lives here.
 All numbers are BIGINT-safe (ints in Python are arbitrary precision).
 """
 
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from .types import CostBreakdown
 
 
@@ -47,21 +47,47 @@ def _calculate_cost_typed(usage: dict, rates: dict) -> CostBreakdown:
         missing = required.difference(usage)
         raise ValueError(f"usage missing keys: {missing}")
 
+    normalized_usage = {}
+    for key in required:
+        value = usage[key]
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"usage {key!r} must be a non-negative integer")
+        normalized_usage[key] = value
+
+    if normalized_usage["cached_tokens"] > normalized_usage["prompt_tokens"]:
+        raise ValueError("usage cached_tokens cannot exceed prompt_tokens")
+
     million = Decimal("1000000")
     
-    uncached_prompt = max(usage["prompt_tokens"] - usage["cached_tokens"], 0)
-    cached_prompt = usage["cached_tokens"]
+    uncached_prompt = (
+        normalized_usage["prompt_tokens"] - normalized_usage["cached_tokens"]
+    )
+    cached_prompt = normalized_usage["cached_tokens"]
 
     # Convert rates to Decimal for precise arithmetic
-    input_price = Decimal(str(rates["input_price"]))
-    cached_rate = rates.get("cached_input_price") or rates["input_price"]
-    cached_input_price = Decimal(str(cached_rate))
-    output_price = Decimal(str(rates["output_price"]))
+    try:
+        input_price = Decimal(str(rates["input_price"]))
+        cached_rate = rates.get("cached_input_price")
+        if cached_rate is None:
+            cached_rate = rates["input_price"]
+        cached_input_price = Decimal(str(cached_rate))
+        output_price = Decimal(str(rates["output_price"]))
+    except (KeyError, InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError("rates must contain valid decimal prices") from exc
+    for name, price in (
+        ("input_price", input_price),
+        ("cached_input_price", cached_input_price),
+        ("output_price", output_price),
+    ):
+        if not price.is_finite() or price < 0:
+            raise ValueError(f"rate {name!r} must be a finite non-negative number")
 
     # Calculate costs using Decimal arithmetic
     prompt_uncached_cost = (Decimal(str(uncached_prompt)) / million) * input_price
     prompt_cached_cost = (Decimal(str(cached_prompt)) / million) * cached_input_price
-    completion_cost = (Decimal(str(usage["completion_tokens"])) / million) * output_price
+    completion_cost = (
+        Decimal(normalized_usage["completion_tokens"]) / million
+    ) * output_price
     
     total = prompt_uncached_cost + prompt_cached_cost + completion_cost
 

--- a/openai_cost_calculator/parser.py
+++ b/openai_cost_calculator/parser.py
@@ -5,7 +5,7 @@ the `responses.create` flavours).
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 
@@ -32,7 +32,7 @@ def extract_model_details(model: str) -> Dict[str, str]:
 
     name, date = m.groups()
     if date is None:
-        date = datetime.utcnow().strftime("%Y-%m-%d")
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     return {"model_name": name, "model_date": date}
 

--- a/openai_cost_calculator/pricing.py
+++ b/openai_cost_calculator/pricing.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 import csv
 import io
+import math
 import time
 import threading
+from datetime import datetime
+from pathlib import Path
 from typing import Dict, Tuple, Iterable, Mapping, Optional, List
 import requests
 
@@ -30,11 +33,13 @@ _LOCK = threading.RLock()
 _OFFLINE_ONLY = False  # if True, never fetch remote CSV
 
 def _validate_date_str(date: str) -> None:
-    # very lightweight guard
-    if not isinstance(date, str) or len(date) != 10:
+    if not isinstance(date, str):
         raise ValueError("model_date must be 'YYYY-MM-DD'")
-    y, m, d = date.split("-")
-    if not (y.isdigit() and m.isdigit() and d.isdigit()):
+    try:
+        parsed = datetime.strptime(date, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError("model_date must be 'YYYY-MM-DD'") from exc
+    if parsed.strftime("%Y-%m-%d") != date:
         raise ValueError("model_date must be 'YYYY-MM-DD'")
 
 def _normalize_row(
@@ -44,14 +49,30 @@ def _normalize_row(
     *,
     minimum_tokens: int = 0,
 ) -> dict:
-    if input_price < 0 or output_price < 0:
-        raise ValueError("Prices must be non-negative")
+    prices = {
+        "input_price": input_price,
+        "output_price": output_price,
+        "cached_input_price": cached_input_price,
+    }
+    for name, value in prices.items():
+        if value is None and name == "cached_input_price":
+            continue
+        if isinstance(value, bool):
+            raise ValueError(f"{name} must be a finite non-negative number")
+        try:
+            number = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be a finite non-negative number") from exc
+        if not math.isfinite(number) or number < 0:
+            raise ValueError(f"{name} must be a finite non-negative number")
     if not isinstance(minimum_tokens, int) or isinstance(minimum_tokens, bool) or minimum_tokens < 0:
         raise ValueError("minimum_tokens must be a non-negative integer")
     row = {
         "input_price": float(input_price),
         "output_price": float(output_price),
-        "cached_input_price": float(cached_input_price) if cached_input_price not in (None, 0) else None,
+        "cached_input_price": (
+            float(cached_input_price) if cached_input_price is not None else None
+        ),
         "minimum_tokens": int(minimum_tokens),
     }
     return row
@@ -164,21 +185,67 @@ def set_offline_mode(offline: bool = True) -> None:
 def _fetch_csv() -> Dict[Tuple[str, str], List[dict]]:
     resp = requests.get(_PRICING_CSV_URL, timeout=5)
     resp.raise_for_status()
-    reader = csv.DictReader(io.StringIO(resp.text))
+    return _parse_csv(resp.text)
+
+
+def _parse_csv(text: str) -> Dict[Tuple[str, str], List[dict]]:
+    reader = csv.DictReader(io.StringIO(text))
+    expected = [
+        "Model Name",
+        "Model Date",
+        "Input Price",
+        "Cached Input Price",
+        "Output Price",
+        "Minimum Tokens",
+    ]
+    legacy = expected[:-1]
+    if reader.fieldnames not in (expected, legacy):
+        raise ValueError(
+            "pricing CSV columns must be: " + ", ".join(expected)
+        )
     data: Dict[Tuple[str, str], Dict[int, dict]] = {}
     for row in reader:
-        key = (row["Model Name"], row["Model Date"])
-        minimum_tokens = _coerce_minimum_tokens(row.get("Minimum Tokens"))
-        cached_raw = (row.get("Cached Input Price") or "").strip()
-        cached_input_price = float(cached_raw) if cached_raw else None
-        parsed = _normalize_row(
-            input_price=float((row.get("Input Price") or "").strip()),
-            output_price=float((row.get("Output Price") or "").strip()),
-            cached_input_price=cached_input_price,
-            minimum_tokens=minimum_tokens,
-        )
+        try:
+            model_name = (row.get("Model Name") or "").strip()
+            model_date = (row.get("Model Date") or "").strip()
+            if not model_name:
+                raise ValueError("Model Name must not be empty")
+            if model_date:
+                _validate_date_str(model_date)
+            key = (model_name, model_date)
+            minimum_tokens = _coerce_minimum_tokens(row.get("Minimum Tokens"))
+            if minimum_tokens in data.get(key, {}):
+                raise ValueError(
+                    f"duplicate tier for {model_name!r}, {model_date!r}, "
+                    f"minimum {minimum_tokens}"
+                )
+            cached_raw = (row.get("Cached Input Price") or "").strip()
+            cached_input_price = float(cached_raw) if cached_raw else None
+            parsed = _normalize_row(
+                input_price=float((row.get("Input Price") or "").strip()),
+                output_price=float((row.get("Output Price") or "").strip()),
+                cached_input_price=cached_input_price,
+                minimum_tokens=minimum_tokens,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid pricing CSV line {reader.line_num}: {exc}") from exc
         data.setdefault(key, {})[minimum_tokens] = parsed
+
+    if not data:
+        raise ValueError("pricing CSV contains no data rows")
+    missing_base = [key for key, tiers in data.items() if 0 not in tiers]
+    if missing_base:
+        model_name, model_date = sorted(missing_base)[0]
+        raise ValueError(
+            f"pricing for {model_name!r} ({model_date or 'undated'}) has no base tier"
+        )
     return {key: _sorted_tiers(by_min) for key, by_min in data.items()}
+
+
+def validate_pricing_file(path: str | Path) -> int:
+    """Validate a pricing CSV and return its number of distinct model/date rows."""
+    pricing = _parse_csv(Path(path).read_text(encoding="utf-8"))
+    return len(pricing)
 
 
 def load_pricing_tiered() -> Dict[Tuple[str, str], List[dict]]:

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import json
 import codecs
+from collections import deque
 import hashlib
 import hmac
+import asyncio
 from typing import Any, AsyncIterator, Optional
 
 import httpx
 
 try:
-    from fastapi import FastAPI, Request
+    from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
     from fastapi.responses import JSONResponse, Response, StreamingResponse
 except ImportError as exc:  # pragma: no cover - exercised when optional deps are absent
     raise ImportError(
@@ -49,6 +51,7 @@ def create_app(
     database_path: Optional[str] = None,
     upstream_selection: Optional[UpstreamSelection] = None,
     admin_token: Optional[str] = None,
+    websocket_connector=None,
 ) -> FastAPI:
     if registry is not None and (ledger_path is not None or database_path is not None):
         raise ValueError("pass either registry or a persistence path, not both")
@@ -74,6 +77,7 @@ def create_app(
     )
     app.state.occ_transport = transport
     app.state.occ_admin_token = admin_token
+    app.state.occ_websocket_connector = websocket_connector
 
     @app.get("/_occ/health")
     async def health(request: Request) -> JSONResponse:
@@ -177,6 +181,10 @@ def create_app(
             turn_label=turn_label,
         )
 
+    @app.websocket("/v1/{path:path}")
+    async def forward_websocket(websocket: WebSocket, path: str) -> None:
+        await _forward_websocket(app, path, websocket)
+
     return app
 
 
@@ -274,11 +282,169 @@ async def _forward_streaming(
     )
 
 
+async def _forward_websocket(app: FastAPI, path: str, websocket: WebSocket) -> None:
+    session_id = _bounded_identifier(websocket.headers.get("x-occ-session"), 128)
+    turn_label = _bounded_identifier(websocket.headers.get("x-occ-turn"), 256)
+    observer = _WebSocketAccountingObserver(
+        app.state.occ_registry,
+        session_id=session_id,
+        turn_label=turn_label,
+    )
+    connector = app.state.occ_websocket_connector
+    if connector is None:
+        try:
+            from websockets.asyncio.client import connect as connector
+        except ImportError as exc:  # pragma: no cover - optional dependency guard
+            app.state.occ_registry.record_error(
+                session_id,
+                "websocket_dependency_missing",
+                "WebSocket forwarding requires the proxy optional dependencies",
+            )
+            await websocket.close(code=1011)
+            return
+
+    subprotocols = _websocket_subprotocols(websocket)
+    try:
+        async with connector(
+            _websocket_upstream_url(app, path, websocket),
+            additional_headers=_websocket_forward_headers(websocket),
+            subprotocols=subprotocols or None,
+            origin=websocket.headers.get("origin"),
+            max_size=None,
+        ) as upstream:
+            selected_subprotocol = getattr(upstream, "subprotocol", None)
+            await websocket.accept(subprotocol=selected_subprotocol)
+            client_task = asyncio.create_task(
+                _relay_client_websocket(websocket, upstream, observer)
+            )
+            upstream_task = asyncio.create_task(
+                _relay_upstream_websocket(websocket, upstream, observer)
+            )
+            done, pending = await asyncio.wait(
+                {client_task, upstream_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            result = next(iter(done)).result()
+            if result["source"] == "upstream":
+                observer.upstream_closed()
+                await websocket.close(
+                    code=_websocket_close_code(result.get("code")),
+                    reason=_websocket_close_reason(result.get("reason")),
+                )
+            else:
+                await upstream.close(
+                    code=_websocket_close_code(result.get("code")),
+                    reason=_websocket_close_reason(result.get("reason")),
+                )
+    except Exception as exc:
+        app.state.occ_registry.record_error(
+            session_id,
+            "websocket_upstream_failed",
+            f"WebSocket upstream connection failed: {type(exc).__name__}",
+        )
+        try:
+            await websocket.close(code=1011)
+        except Exception:
+            pass
+
+
+async def _relay_client_websocket(
+    websocket: WebSocket,
+    upstream: Any,
+    observer: "_WebSocketAccountingObserver",
+) -> dict[str, Any]:
+    try:
+        while True:
+            message = await websocket.receive()
+            if message["type"] == "websocket.disconnect":
+                return {
+                    "source": "client",
+                    "code": message.get("code", 1000),
+                    "reason": message.get("reason", ""),
+                }
+            if message.get("text") is not None:
+                payload: str | bytes = message["text"]
+            elif message.get("bytes") is not None:
+                payload = message["bytes"]
+            else:
+                continue
+            observer.observe_client(payload)
+            await upstream.send(payload)
+    except WebSocketDisconnect as exc:
+        return {"source": "client", "code": exc.code, "reason": ""}
+
+
+async def _relay_upstream_websocket(
+    websocket: WebSocket,
+    upstream: Any,
+    observer: "_WebSocketAccountingObserver",
+) -> dict[str, Any]:
+    try:
+        async for payload in upstream:
+            observer.observe_upstream(payload)
+            if isinstance(payload, bytes):
+                await websocket.send_bytes(payload)
+            else:
+                await websocket.send_text(payload)
+        return {"source": "upstream", "code": 1000, "reason": ""}
+    except Exception as exc:
+        return {
+            "source": "upstream",
+            "code": getattr(exc, "code", 1011),
+            "reason": getattr(exc, "reason", ""),
+        }
+
+
 def _client(app: FastAPI) -> httpx.AsyncClient:
     return httpx.AsyncClient(
         timeout=None,
         transport=app.state.occ_transport,
     )
+
+
+def _websocket_upstream_url(app: FastAPI, path: str, websocket: WebSocket) -> str:
+    base = app.state.occ_upstream
+    if base.startswith("https://"):
+        base = f"wss://{base.removeprefix('https://')}"
+    elif base.startswith("http://"):
+        base = f"ws://{base.removeprefix('http://')}"
+    url = f"{base}/{path}"
+    if websocket.url.query:
+        url = f"{url}?{websocket.url.query}"
+    return url
+
+
+def _websocket_forward_headers(websocket: WebSocket) -> list[tuple[str, str]]:
+    excluded = set(_HOP_BY_HOP_HEADERS)
+    excluded.update(
+        {
+            "host",
+            "content-length",
+            "origin",
+            "x-occ-session",
+            "x-occ-turn",
+        }
+    )
+    for name in websocket.headers:
+        if name.lower().startswith("sec-websocket-"):
+            excluded.add(name.lower())
+    for value in websocket.headers.getlist("connection"):
+        excluded.update(token.strip().lower() for token in value.split(","))
+    return [
+        (name.decode("latin-1"), value.decode("latin-1"))
+        for name, value in websocket.headers.raw
+        if name.decode("latin-1").lower() not in excluded
+    ]
+
+
+def _websocket_subprotocols(websocket: WebSocket) -> list[str]:
+    protocols = []
+    for value in websocket.headers.getlist("sec-websocket-protocol"):
+        protocols.extend(item.strip() for item in value.split(",") if item.strip())
+    return protocols
 
 
 def _upstream_url(app: FastAPI, path: str, request: Request) -> str:
@@ -436,6 +602,111 @@ class _SSEUsageParser:
         if "model" not in usage_payload and isinstance(self._default_model, str):
             usage_payload = {**usage_payload, "model": self._default_model}
         self.usage_payload = usage_payload
+
+
+class _WebSocketAccountingObserver:
+    def __init__(
+        self,
+        registry: TrackerRegistry,
+        *,
+        session_id: Optional[str],
+        turn_label: Optional[str],
+    ) -> None:
+        self._registry = registry
+        self._session_id = session_id
+        self._turn_label = turn_label
+        self._pending_models: deque[Optional[str]] = deque()
+        self._terminal_ids: deque[str] = deque()
+        self._terminal_id_set: set[str] = set()
+
+    def observe_client(self, message: str | bytes) -> None:
+        payload = _websocket_json(message)
+        if payload is None or payload.get("type") != "response.create":
+            return
+        response = payload.get("response")
+        model = response.get("model") if isinstance(response, dict) else None
+        if not isinstance(model, str):
+            model = payload.get("model")
+        self._pending_models.append(model if isinstance(model, str) else None)
+
+    def observe_upstream(self, message: str | bytes) -> None:
+        payload = _websocket_json(message)
+        if payload is None:
+            return
+        event_type = payload.get("type")
+        if event_type not in {
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+        }:
+            return
+        response = payload.get("response")
+        response_payload = response if isinstance(response, dict) else payload
+        terminal_id = response_payload.get("id")
+        if not isinstance(terminal_id, str):
+            terminal_id = hashlib.sha256(
+                json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+            ).hexdigest()
+        if terminal_id in self._terminal_id_set:
+            return
+        self._remember_terminal(terminal_id)
+        model = self._pending_models.popleft() if self._pending_models else None
+
+        if event_type == "response.completed":
+            if "model" not in response_payload and model is not None:
+                response_payload = {**response_payload, "model": model}
+            _record_json_payload(
+                self._registry,
+                self._session_id,
+                self._turn_label,
+                response_payload,
+            )
+            return
+        self._registry.record_error(
+            self._session_id,
+            "websocket_response_failed",
+            f"WebSocket response ended with terminal event {event_type}",
+        )
+
+    def upstream_closed(self) -> None:
+        if self._pending_models:
+            self._registry.record_error(
+                self._session_id,
+                "websocket_missing_terminal",
+                "WebSocket upstream closed with unfinished response requests",
+            )
+            self._pending_models.clear()
+
+    def _remember_terminal(self, terminal_id: str) -> None:
+        self._terminal_ids.append(terminal_id)
+        self._terminal_id_set.add(terminal_id)
+        if len(self._terminal_ids) > 1_024:
+            removed = self._terminal_ids.popleft()
+            self._terminal_id_set.discard(removed)
+
+
+def _websocket_json(message: str | bytes) -> Optional[dict]:
+    if isinstance(message, bytes):
+        try:
+            message = message.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    try:
+        payload = json.loads(message)
+    except (TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _websocket_close_code(value: Any) -> int:
+    return value if isinstance(value, int) and 1000 <= value <= 4999 else 1011
+
+
+def _websocket_close_reason(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    encoded = value.encode("utf-8")[:123]
+    return encoded.decode("utf-8", errors="ignore")
 
 
 def _bounded_identifier(value: Optional[str], limit: int) -> Optional[str]:

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import codecs
+import hashlib
 from typing import Any, AsyncIterator, Optional
 
 import httpx
@@ -73,8 +75,8 @@ def create_app(
     @app.api_route("/v1/{path:path}", methods=["GET", "POST"])
     async def forward(path: str, request: Request) -> Response:
         body = await request.body()
-        session_id = request.headers.get("x-occ-session")
-        turn_label = request.headers.get("x-occ-turn")
+        session_id = _bounded_identifier(request.headers.get("x-occ-session"), 128)
+        turn_label = _bounded_identifier(request.headers.get("x-occ-turn"), 256)
         request_payload = _json_from_bytes(body)
 
         if request.method == "POST" and request_payload.get("stream") is True:
@@ -160,6 +162,13 @@ async def _forward_streaming(
                 parser.feed(chunk)
                 yield chunk
             completed = True
+        except Exception as exc:
+            app.state.occ_registry.record_error(
+                session_id,
+                "stream_interrupted",
+                f"upstream stream ended unexpectedly: {type(exc).__name__}",
+            )
+            raise
         finally:
             parser.close()
             if completed and upstream_response.status_code < 400:
@@ -203,7 +212,7 @@ def _upstream_url(app: FastAPI, path: str, request: Request) -> str:
 
 def _forward_headers(request: Request) -> list[tuple[bytes, bytes]]:
     excluded = {name.encode("ascii") for name in _HOP_BY_HOP_HEADERS}
-    excluded.update({b"host", b"content-length"})
+    excluded.update({b"host", b"content-length", b"x-occ-session", b"x-occ-turn"})
     for value in request.headers.getlist("connection"):
         excluded.update(token.strip().lower().encode("ascii") for token in value.split(","))
     return [
@@ -288,40 +297,43 @@ def _sse_data(payload: dict) -> bytes:
 class _SSEUsageParser:
     def __init__(self, *, default_model: Any = None) -> None:
         self._buffer = ""
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        self._pending_cr = False
         self._default_model = default_model
         self.usage_payload: Optional[dict] = None
 
     def feed(self, chunk: bytes) -> None:
         if not chunk:
             return
-        self._buffer += chunk.decode("utf-8", errors="ignore")
+        self._append_text(self._decoder.decode(chunk))
         while True:
-            event, separator = self._pop_event()
-            if separator is None:
+            event = self._pop_event()
+            if event is None:
                 return
             self._handle_event(event)
 
     def close(self) -> None:
+        self._append_text(self._decoder.decode(b"", final=True), final=True)
         if self._buffer.strip():
             self._handle_event(self._buffer)
         self._buffer = ""
 
-    def _pop_event(self) -> tuple[str, Optional[str]]:
-        indexes = [
-            index
-            for index in (
-                self._buffer.find("\n\n"),
-                self._buffer.find("\r\n\r\n"),
-            )
-            if index != -1
-        ]
-        if not indexes:
-            return "", None
-        index = min(indexes)
-        separator = "\r\n\r\n" if self._buffer.startswith("\r\n\r\n", index) else "\n\n"
+    def _append_text(self, text: str, *, final: bool = False) -> None:
+        if self._pending_cr:
+            text = "\r" + text
+            self._pending_cr = False
+        if text.endswith("\r") and not final:
+            text = text[:-1]
+            self._pending_cr = True
+        self._buffer += text.replace("\r\n", "\n").replace("\r", "\n")
+
+    def _pop_event(self) -> Optional[str]:
+        index = self._buffer.find("\n\n")
+        if index == -1:
+            return None
         event = self._buffer[:index]
-        self._buffer = self._buffer[index + len(separator) :]
-        return event, separator
+        self._buffer = self._buffer[index + 2 :]
+        return event
 
     def _handle_event(self, event: str) -> None:
         data_lines = []
@@ -346,6 +358,16 @@ class _SSEUsageParser:
         if "model" not in usage_payload and isinstance(self._default_model, str):
             usage_payload = {**usage_payload, "model": self._default_model}
         self.usage_payload = usage_payload
+
+
+def _bounded_identifier(value: Optional[str], limit: int) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = "".join(character if character.isprintable() else "?" for character in value)
+    if len(cleaned) <= limit:
+        return cleaned
+    digest = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:12]
+    return f"{cleaned[: limit - 13]}#{digest}"
 
 
 app = create_app()

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import codecs
 import hashlib
+import hmac
 from typing import Any, AsyncIterator, Optional
 
 import httpx
@@ -47,6 +48,7 @@ def create_app(
     ledger_path: Optional[str] = None,
     database_path: Optional[str] = None,
     upstream_selection: Optional[UpstreamSelection] = None,
+    admin_token: Optional[str] = None,
 ) -> FastAPI:
     if registry is not None and (ledger_path is not None or database_path is not None):
         raise ValueError("pass either registry or a persistence path, not both")
@@ -71,9 +73,13 @@ def create_app(
         else default_registry
     )
     app.state.occ_transport = transport
+    app.state.occ_admin_token = admin_token
 
     @app.get("/_occ/health")
-    async def health() -> JSONResponse:
+    async def health(request: Request) -> JSONResponse:
+        unauthorized = _admin_auth_error(app, request)
+        if unauthorized is not None:
+            return unauthorized
         persistence = app.state.occ_registry.persistence_status()
         status = 200 if persistence["healthy"] else 503
         selection = app.state.occ_upstream_selection
@@ -92,11 +98,17 @@ def create_app(
         )
 
     @app.get("/_occ/costs")
-    async def costs(session: Optional[str] = None) -> JSONResponse:
+    async def costs(request: Request, session: Optional[str] = None) -> JSONResponse:
+        unauthorized = _admin_auth_error(app, request)
+        if unauthorized is not None:
+            return unauthorized
         return JSONResponse(app.state.occ_registry.summary(session))
 
     @app.post("/_occ/checkpoint")
-    async def checkpoint(session: Optional[str] = None) -> JSONResponse:
+    async def checkpoint(request: Request, session: Optional[str] = None) -> JSONResponse:
+        unauthorized = _admin_auth_error(app, request)
+        if unauthorized is not None:
+            return unauthorized
         try:
             payload = app.state.occ_registry.checkpoint(session)
         except LedgerError as exc:
@@ -107,7 +119,10 @@ def create_app(
         return JSONResponse(payload)
 
     @app.post("/_occ/reset")
-    async def reset() -> JSONResponse:
+    async def reset(request: Request) -> JSONResponse:
+        unauthorized = _admin_auth_error(app, request)
+        if unauthorized is not None:
+            return unauthorized
         try:
             app.state.occ_registry.reset()
         except LedgerError as exc:
@@ -118,7 +133,10 @@ def create_app(
         return JSONResponse({"ok": True})
 
     @app.get("/_occ/costs/stream")
-    async def cost_stream() -> StreamingResponse:
+    async def cost_stream(request: Request) -> Response:
+        unauthorized = _admin_auth_error(app, request)
+        if unauthorized is not None:
+            return unauthorized
         queue = app.state.occ_registry.subscribe()
 
         async def events() -> AsyncIterator[bytes]:
@@ -428,6 +446,30 @@ def _bounded_identifier(value: Optional[str], limit: int) -> Optional[str]:
         return cleaned
     digest = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:12]
     return f"{cleaned[: limit - 13]}#{digest}"
+
+
+def _admin_auth_error(app: FastAPI, request: Request) -> Optional[JSONResponse]:
+    expected = app.state.occ_admin_token
+    if expected is None:
+        return None
+    authorization = request.headers.get("authorization", "")
+    scheme, separator, supplied = authorization.partition(" ")
+    if (
+        not separator
+        or scheme.lower() != "bearer"
+        or not hmac.compare_digest(supplied, expected)
+    ):
+        return JSONResponse(
+            {
+                "error": {
+                    "code": "admin_auth_required",
+                    "message": "valid administrative authentication is required",
+                }
+            },
+            status_code=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return None
 
 
 app = create_app()

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -45,10 +45,13 @@ def create_app(
     registry: Optional[TrackerRegistry] = None,
     transport: Optional[httpx.AsyncBaseTransport] = None,
     ledger_path: Optional[str] = None,
+    database_path: Optional[str] = None,
     upstream_selection: Optional[UpstreamSelection] = None,
 ) -> FastAPI:
-    if registry is not None and ledger_path is not None:
-        raise ValueError("pass either registry or ledger_path, not both")
+    if registry is not None and (ledger_path is not None or database_path is not None):
+        raise ValueError("pass either registry or a persistence path, not both")
+    if ledger_path is not None and database_path is not None:
+        raise ValueError("pass either ledger_path or database_path, not both")
     app = FastAPI()
     if upstream_selection is not None:
         upstream = upstream_selection.url
@@ -63,7 +66,9 @@ def create_app(
     app.state.occ_registry = (
         registry
         if registry is not None
-        else TrackerRegistry(ledger_path=ledger_path) if ledger_path is not None else default_registry
+        else TrackerRegistry(ledger_path=ledger_path, database_path=database_path)
+        if ledger_path is not None or database_path is not None
+        else default_registry
     )
     app.state.occ_transport = transport
 

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -17,6 +17,7 @@ except ImportError as exc:  # pragma: no cover - exercised when optional deps ar
     ) from exc
 
 from openai_cost_calculator.parser import extract_usage_from_payload
+from openai_cost_calculator.proxy.ledger import LedgerError
 from openai_cost_calculator.proxy.registry import TrackerRegistry, default_registry
 
 
@@ -38,11 +39,24 @@ def create_app(
     upstream: str = "https://api.openai.com/v1",
     registry: Optional[TrackerRegistry] = None,
     transport: Optional[httpx.AsyncBaseTransport] = None,
+    ledger_path: Optional[str] = None,
 ) -> FastAPI:
+    if registry is not None and ledger_path is not None:
+        raise ValueError("pass either registry or ledger_path, not both")
     app = FastAPI()
     app.state.occ_upstream = upstream.rstrip("/")
-    app.state.occ_registry = registry or default_registry
+    app.state.occ_registry = (
+        registry
+        if registry is not None
+        else TrackerRegistry(ledger_path=ledger_path) if ledger_path is not None else default_registry
+    )
     app.state.occ_transport = transport
+
+    @app.get("/_occ/health")
+    async def health() -> JSONResponse:
+        persistence = app.state.occ_registry.persistence_status()
+        status = 200 if persistence["healthy"] else 503
+        return JSONResponse({"ok": status == 200, "persistence": persistence}, status_code=status)
 
     @app.get("/_occ/costs")
     async def costs(session: Optional[str] = None) -> JSONResponse:
@@ -50,11 +64,24 @@ def create_app(
 
     @app.post("/_occ/checkpoint")
     async def checkpoint(session: Optional[str] = None) -> JSONResponse:
-        return JSONResponse(app.state.occ_registry.checkpoint(session))
+        try:
+            payload = app.state.occ_registry.checkpoint(session)
+        except LedgerError as exc:
+            return JSONResponse(
+                {"error": {"code": "ledger_write_failed", "message": str(exc)}},
+                status_code=503,
+            )
+        return JSONResponse(payload)
 
     @app.post("/_occ/reset")
     async def reset() -> JSONResponse:
-        app.state.occ_registry.reset()
+        try:
+            app.state.occ_registry.reset()
+        except LedgerError as exc:
+            return JSONResponse(
+                {"error": {"code": "ledger_write_failed", "message": str(exc)}},
+                status_code=503,
+            )
         return JSONResponse({"ok": True})
 
     @app.get("/_occ/costs/stream")

--- a/openai_cost_calculator/proxy/app.py
+++ b/openai_cost_calculator/proxy/app.py
@@ -19,6 +19,11 @@ except ImportError as exc:  # pragma: no cover - exercised when optional deps ar
 from openai_cost_calculator.parser import extract_usage_from_payload
 from openai_cost_calculator.proxy.ledger import LedgerError
 from openai_cost_calculator.proxy.registry import TrackerRegistry, default_registry
+from openai_cost_calculator.proxy.upstreams import (
+    PLATFORM_UPSTREAM,
+    UpstreamSelection,
+    classify_upstream,
+)
 
 
 _HOP_BY_HOP_HEADERS = {
@@ -36,15 +41,25 @@ _HOP_BY_HOP_HEADERS = {
 
 def create_app(
     *,
-    upstream: str = "https://api.openai.com/v1",
+    upstream: str = PLATFORM_UPSTREAM,
     registry: Optional[TrackerRegistry] = None,
     transport: Optional[httpx.AsyncBaseTransport] = None,
     ledger_path: Optional[str] = None,
+    upstream_selection: Optional[UpstreamSelection] = None,
 ) -> FastAPI:
     if registry is not None and ledger_path is not None:
         raise ValueError("pass either registry or ledger_path, not both")
     app = FastAPI()
+    if upstream_selection is not None:
+        upstream = upstream_selection.url
     app.state.occ_upstream = upstream.rstrip("/")
+    app.state.occ_upstream_selection = upstream_selection or UpstreamSelection(
+        auth_mode="unspecified",
+        category=classify_upstream(app.state.occ_upstream),
+        url=app.state.occ_upstream,
+        explicit_override=True,
+        detection_source="application configuration",
+    )
     app.state.occ_registry = (
         registry
         if registry is not None
@@ -56,7 +71,20 @@ def create_app(
     async def health() -> JSONResponse:
         persistence = app.state.occ_registry.persistence_status()
         status = 200 if persistence["healthy"] else 503
-        return JSONResponse({"ok": status == 200, "persistence": persistence}, status_code=status)
+        selection = app.state.occ_upstream_selection
+        return JSONResponse(
+            {
+                "ok": status == 200,
+                "persistence": persistence,
+                "routing": {
+                    "auth_mode": selection.auth_mode,
+                    "upstream_category": selection.category,
+                    "explicit_override": selection.explicit_override,
+                    "detection_source": selection.detection_source,
+                },
+            },
+            status_code=status,
+        )
 
     @app.get("/_occ/costs")
     async def costs(session: Optional[str] = None) -> JSONResponse:

--- a/openai_cost_calculator/proxy/ledger.py
+++ b/openai_cost_calculator/proxy/ledger.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import sqlite3
 import tempfile
+from decimal import Decimal
 from typing import Any
 
 
@@ -212,7 +213,7 @@ class SQLiteLedger:
         payload: dict[str, Any],
         *,
         max_sessions: int,
-        max_calls_per_session: int,
+        max_calls_per_session: int | None,
     ) -> None:
         try:
             self._connection.execute("BEGIN IMMEDIATE")
@@ -285,7 +286,7 @@ class SQLiteLedger:
             self._rollback()
             raise LedgerError(f"cannot append SQLite diagnostic: {exc}") from exc
 
-    def checkpoint(self, session: str) -> list[dict[str, Any]]:
+    def checkpoint(self, session: str) -> dict[str, Any]:
         try:
             self._connection.execute("BEGIN IMMEDIATE")
             row = self._connection.execute(
@@ -301,8 +302,12 @@ class SQLiteLedger:
                 FROM calls WHERE session = ? AND id > ? ORDER BY id
                 """,
                 (session, cursor),
-            ).fetchall()
-            next_cursor = int(rows[-1]["id"]) if rows else cursor
+            )
+            state = _empty_checkpoint_state()
+            next_cursor = cursor
+            for item in rows:
+                next_cursor = int(item["id"])
+                _accumulate_checkpoint_row(state, item)
             self._connection.execute(
                 """
                 INSERT INTO checkpoints (session, call_id) VALUES (?, ?)
@@ -311,10 +316,93 @@ class SQLiteLedger:
                 (session, next_cursor),
             )
             self._connection.execute("COMMIT")
-            return [self._call_payload(item) for item in rows]
+            return _checkpoint_summary(session, state)
         except sqlite3.Error as exc:
             self._rollback()
             raise LedgerError(f"cannot consume SQLite checkpoint: {exc}") from exc
+
+    def summary(
+        self,
+        session_id: str | None,
+        initial_totals: dict[str, Decimal],
+    ) -> dict[str, Any]:
+        states: dict[str, dict[str, Any]] = {}
+        parameters: tuple[Any, ...] = ()
+        where = ""
+        if session_id is not None:
+            where = " WHERE session = ?"
+            parameters = (session_id,)
+        try:
+            cursor = self._connection.execute(
+                """
+                SELECT id, session, turn_label, model, prompt_tokens,
+                       completion_tokens, cached_tokens, prompt_cost_uncached,
+                       prompt_cost_cached, completion_cost, total_cost, timestamp
+                FROM calls
+                """
+                + where
+                + " ORDER BY id",
+                parameters,
+            )
+            for row in cursor:
+                state = states.setdefault(row["session"], _empty_summary_state())
+                _accumulate_summary_row(state, row)
+
+            diagnostic_cursor = self._connection.execute(
+                "SELECT session, code, message, timestamp FROM diagnostics"
+                + where
+                + " ORDER BY id",
+                parameters,
+            )
+            for row in diagnostic_cursor:
+                state = states.setdefault(row["session"], _empty_summary_state())
+                state["errors"].append(
+                    {
+                        "code": row["code"],
+                        "message": row["message"],
+                        "timestamp": row["timestamp"],
+                    }
+                )
+        except sqlite3.Error as exc:
+            raise LedgerError(f"cannot summarize SQLite ledger: {exc}") from exc
+
+        sessions = {}
+        grand_total = Decimal("0")
+        for session, state in sorted(states.items()):
+            total = state["total_cost"]
+            grand_total += total
+            historical = min(initial_totals.get(session, Decimal("0")), total)
+            sessions[session] = {
+                "session_total": f"{total:.8f}",
+                "historical_total": f"{historical:.8f}",
+                "process_total": f"{(total - historical):.8f}",
+                "turns": [_turn_summary(turn) for turn in state["turns"].values()],
+                "errors": state["errors"],
+                "latest_call": state["latest_call"],
+            }
+        return {"sessions": sessions, "grand_total": f"{grand_total:.8f}"}
+
+    def totals(self) -> dict[str, Decimal]:
+        totals: dict[str, Decimal] = {}
+        try:
+            for row in self._connection.execute(
+                "SELECT session, total_cost FROM calls ORDER BY id"
+            ):
+                totals[row["session"]] = totals.get(
+                    row["session"], Decimal("0")
+                ) + Decimal(row["total_cost"])
+        except (sqlite3.Error, ValueError) as exc:
+            raise LedgerError(f"cannot read SQLite totals: {exc}") from exc
+        return totals
+
+    def generation(self) -> int:
+        try:
+            row = self._connection.execute(
+                "SELECT value FROM metadata WHERE key = 'reset_generation'"
+            ).fetchone()
+        except sqlite3.Error as exc:
+            raise LedgerError(f"cannot read SQLite generation: {exc}") from exc
+        return int(row[0]) if row is not None else 0
 
     def reset(self) -> None:
         try:
@@ -322,6 +410,12 @@ class SQLiteLedger:
             self._connection.execute("DELETE FROM calls")
             self._connection.execute("DELETE FROM diagnostics")
             self._connection.execute("DELETE FROM checkpoints")
+            self._connection.execute(
+                """
+                UPDATE metadata SET value = CAST(value AS INTEGER) + 1
+                WHERE key = 'reset_generation'
+                """
+            )
             self._connection.execute("COMMIT")
         except sqlite3.Error as exc:
             self._rollback()
@@ -377,6 +471,12 @@ class SQLiteLedger:
             )
         elif row[0] != str(SCHEMA_VERSION):
             raise LedgerError(f"unsupported SQLite ledger schema: {row[0]!r}")
+        self._connection.execute(
+            """
+            INSERT OR IGNORE INTO metadata (key, value)
+            VALUES ('reset_generation', '0')
+            """
+        )
 
     def _enforce_capacity(
         self,
@@ -390,7 +490,7 @@ class SQLiteLedger:
             "SELECT COUNT(*) FROM calls WHERE session = ?",
             (session,),
         ).fetchone()[0]
-        if count >= max_calls_per_session:
+        if max_calls_per_session is not None and count >= max_calls_per_session:
             raise LedgerError("per-session SQLite call capacity reached")
 
     def _enforce_session_capacity(self, session: str, max_sessions: int) -> None:
@@ -434,3 +534,105 @@ class SQLiteLedger:
             self._connection.execute("ROLLBACK")
         except sqlite3.Error:
             pass
+
+
+def _empty_summary_state() -> dict[str, Any]:
+    return {
+        "total_cost": Decimal("0"),
+        "turns": {},
+        "errors": [],
+        "latest_call": None,
+    }
+
+
+def _accumulate_summary_row(state: dict[str, Any], row: sqlite3.Row) -> None:
+    cost = Decimal(row["total_cost"])
+    state["total_cost"] += cost
+    label = row["turn_label"]
+    turn = state["turns"].setdefault(
+        label,
+        {
+            "label": label,
+            "num_calls": 0,
+            "total_cost": Decimal("0"),
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "cached_tokens": 0,
+            "cost_by_model": {},
+        },
+    )
+    turn["num_calls"] += 1
+    turn["total_cost"] += cost
+    turn["prompt_tokens"] += row["prompt_tokens"]
+    turn["completion_tokens"] += row["completion_tokens"]
+    turn["cached_tokens"] += row["cached_tokens"]
+    model_costs = turn["cost_by_model"]
+    model_costs[row["model"]] = model_costs.get(row["model"], Decimal("0")) + cost
+    state["latest_call"] = SQLiteLedger._call_payload(row)
+
+
+def _turn_summary(turn: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **{key: value for key, value in turn.items() if key not in {"total_cost", "cost_by_model"}},
+        "total_cost": f"{turn['total_cost']:.8f}",
+        "cost_by_model": {
+            model: f"{cost:.8f}" for model, cost in turn["cost_by_model"].items()
+        },
+    }
+
+
+def _empty_checkpoint_state() -> dict[str, Any]:
+    return {
+        "num_calls": 0,
+        "total_cost": Decimal("0"),
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "cached_tokens": 0,
+        "models": {},
+    }
+
+
+def _accumulate_checkpoint_row(state: dict[str, Any], row: sqlite3.Row) -> None:
+    cost = Decimal(row["total_cost"])
+    state["num_calls"] += 1
+    state["total_cost"] += cost
+    state["prompt_tokens"] += row["prompt_tokens"]
+    state["completion_tokens"] += row["completion_tokens"]
+    state["cached_tokens"] += row["cached_tokens"]
+    model = state["models"].setdefault(
+        row["model"],
+        {
+            "num_calls": 0,
+            "total_cost": Decimal("0"),
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "cached_tokens": 0,
+        },
+    )
+    model["num_calls"] += 1
+    model["total_cost"] += cost
+    model["prompt_tokens"] += row["prompt_tokens"]
+    model["completion_tokens"] += row["completion_tokens"]
+    model["cached_tokens"] += row["cached_tokens"]
+
+
+def _checkpoint_summary(session: str, state: dict[str, Any]) -> dict[str, Any]:
+    models = {
+        name: {
+            **{key: value for key, value in model.items() if key != "total_cost"},
+            "total_cost": f"{model['total_cost']:.8f}",
+        }
+        for name, model in state["models"].items()
+    }
+    return {
+        "session": session,
+        "num_calls": state["num_calls"],
+        "total_cost": f"{state['total_cost']:.8f}",
+        "prompt_tokens": state["prompt_tokens"],
+        "completion_tokens": state["completion_tokens"],
+        "cached_tokens": state["cached_tokens"],
+        "models": models,
+        "cost_by_model": {
+            name: model["total_cost"] for name, model in models.items()
+        },
+    }

--- a/openai_cost_calculator/proxy/ledger.py
+++ b/openai_cost_calculator/proxy/ledger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import sqlite3
 import tempfile
 from typing import Any
 
@@ -119,3 +120,317 @@ class DurableLedger:
             os.fsync(descriptor)
         finally:
             os.close(descriptor)
+
+
+class SQLiteLedger:
+    """Concurrent transactional accounting storage backed by stdlib SQLite."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+        if self.path.is_symlink():
+            raise LedgerError("refusing to open a symlinked SQLite ledger")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._connection = sqlite3.connect(
+                self.path,
+                timeout=5,
+                isolation_level=None,
+                check_same_thread=False,
+            )
+            self._connection.row_factory = sqlite3.Row
+            self._connection.execute("PRAGMA journal_mode=WAL")
+            self._connection.execute("PRAGMA synchronous=FULL")
+            self._connection.execute("PRAGMA foreign_keys=ON")
+            self._connection.execute("PRAGMA busy_timeout=5000")
+            self._initialize()
+            self.path.chmod(0o600)
+        except sqlite3.Error as exc:
+            raise LedgerError(f"cannot open SQLite ledger: {exc}") from exc
+
+    def load(self) -> dict[str, Any]:
+        sessions: dict[str, dict[str, Any]] = {}
+        try:
+            calls = self._connection.execute(
+                """
+                SELECT id, session, turn_label, model, prompt_tokens,
+                       completion_tokens, cached_tokens, prompt_cost_uncached,
+                       prompt_cost_cached, completion_cost, total_cost, timestamp
+                FROM calls ORDER BY id
+                """
+            ).fetchall()
+            turns_by_session: dict[str, dict[str | None, dict[str, Any]]] = {}
+            for row in calls:
+                session = row["session"]
+                state = sessions.setdefault(
+                    session,
+                    {"turns": [], "errors": [], "checkpoint_cursor": 0},
+                )
+                by_label = turns_by_session.setdefault(session, {})
+                label = row["turn_label"]
+                turn = by_label.get(label)
+                if turn is None:
+                    turn = {"label": label, "records": []}
+                    by_label[label] = turn
+                    state["turns"].append(turn)
+                turn["records"].append(self._call_payload(row))
+
+            for row in self._connection.execute(
+                "SELECT session, code, message, timestamp FROM diagnostics ORDER BY id"
+            ):
+                state = sessions.setdefault(
+                    row["session"],
+                    {"turns": [], "errors": [], "checkpoint_cursor": 0},
+                )
+                state["errors"].append(
+                    {
+                        "code": row["code"],
+                        "message": row["message"],
+                        "timestamp": row["timestamp"],
+                    }
+                )
+
+            for row in self._connection.execute(
+                "SELECT session, call_id FROM checkpoints"
+            ):
+                state = sessions.setdefault(
+                    row["session"],
+                    {"turns": [], "errors": [], "checkpoint_cursor": 0},
+                )
+                count = self._connection.execute(
+                    "SELECT COUNT(*) FROM calls WHERE session = ? AND id <= ?",
+                    (row["session"], row["call_id"]),
+                ).fetchone()[0]
+                state["checkpoint_cursor"] = count
+        except sqlite3.Error as exc:
+            raise LedgerError(f"cannot read SQLite ledger: {exc}") from exc
+        return {"schema_version": SCHEMA_VERSION, "sessions": sessions}
+
+    def append_call(
+        self,
+        session: str,
+        turn_label: str | None,
+        payload: dict[str, Any],
+        *,
+        max_sessions: int,
+        max_calls_per_session: int,
+    ) -> None:
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            self._enforce_capacity(
+                session,
+                max_sessions=max_sessions,
+                max_calls_per_session=max_calls_per_session,
+            )
+            cost = payload["cost"]
+            self._connection.execute(
+                """
+                INSERT INTO calls (
+                    session, turn_label, model, prompt_tokens, completion_tokens,
+                    cached_tokens, prompt_cost_uncached, prompt_cost_cached,
+                    completion_cost, total_cost, timestamp
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session,
+                    turn_label,
+                    payload["model"],
+                    payload["prompt_tokens"],
+                    payload["completion_tokens"],
+                    payload["cached_tokens"],
+                    cost["prompt_cost_uncached"],
+                    cost["prompt_cost_cached"],
+                    cost["completion_cost"],
+                    cost["total_cost"],
+                    payload["timestamp"],
+                ),
+            )
+            self._connection.execute("COMMIT")
+        except LedgerError:
+            self._rollback()
+            raise
+        except (KeyError, sqlite3.Error) as exc:
+            self._rollback()
+            raise LedgerError(f"cannot append SQLite call: {exc}") from exc
+
+    def append_error(
+        self,
+        session: str,
+        error: dict[str, Any],
+        *,
+        max_sessions: int,
+        max_errors: int,
+    ) -> None:
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            self._enforce_session_capacity(session, max_sessions)
+            self._connection.execute(
+                "INSERT INTO diagnostics (session, code, message, timestamp) VALUES (?, ?, ?, ?)",
+                (session, error["code"], error["message"], error["timestamp"]),
+            )
+            self._connection.execute(
+                """
+                DELETE FROM diagnostics
+                WHERE session = ? AND id NOT IN (
+                    SELECT id FROM diagnostics WHERE session = ?
+                    ORDER BY id DESC LIMIT ?
+                )
+                """,
+                (session, session, max_errors),
+            )
+            self._connection.execute("COMMIT")
+        except LedgerError:
+            self._rollback()
+            raise
+        except (KeyError, sqlite3.Error) as exc:
+            self._rollback()
+            raise LedgerError(f"cannot append SQLite diagnostic: {exc}") from exc
+
+    def checkpoint(self, session: str) -> list[dict[str, Any]]:
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            row = self._connection.execute(
+                "SELECT call_id FROM checkpoints WHERE session = ?",
+                (session,),
+            ).fetchone()
+            cursor = int(row[0]) if row is not None else 0
+            rows = self._connection.execute(
+                """
+                SELECT id, session, turn_label, model, prompt_tokens,
+                       completion_tokens, cached_tokens, prompt_cost_uncached,
+                       prompt_cost_cached, completion_cost, total_cost, timestamp
+                FROM calls WHERE session = ? AND id > ? ORDER BY id
+                """,
+                (session, cursor),
+            ).fetchall()
+            next_cursor = int(rows[-1]["id"]) if rows else cursor
+            self._connection.execute(
+                """
+                INSERT INTO checkpoints (session, call_id) VALUES (?, ?)
+                ON CONFLICT(session) DO UPDATE SET call_id = excluded.call_id
+                """,
+                (session, next_cursor),
+            )
+            self._connection.execute("COMMIT")
+            return [self._call_payload(item) for item in rows]
+        except sqlite3.Error as exc:
+            self._rollback()
+            raise LedgerError(f"cannot consume SQLite checkpoint: {exc}") from exc
+
+    def reset(self) -> None:
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+            self._connection.execute("DELETE FROM calls")
+            self._connection.execute("DELETE FROM diagnostics")
+            self._connection.execute("DELETE FROM checkpoints")
+            self._connection.execute("COMMIT")
+        except sqlite3.Error as exc:
+            self._rollback()
+            raise LedgerError(f"cannot reset SQLite ledger: {exc}") from exc
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def _initialize(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS calls (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session TEXT NOT NULL,
+                turn_label TEXT,
+                model TEXT NOT NULL,
+                prompt_tokens INTEGER NOT NULL CHECK(prompt_tokens >= 0),
+                completion_tokens INTEGER NOT NULL CHECK(completion_tokens >= 0),
+                cached_tokens INTEGER NOT NULL CHECK(cached_tokens >= 0),
+                prompt_cost_uncached TEXT NOT NULL,
+                prompt_cost_cached TEXT NOT NULL,
+                completion_cost TEXT NOT NULL,
+                total_cost TEXT NOT NULL,
+                timestamp REAL NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS calls_session_id ON calls(session, id);
+            CREATE TABLE IF NOT EXISTS diagnostics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session TEXT NOT NULL,
+                code TEXT NOT NULL,
+                message TEXT NOT NULL,
+                timestamp REAL NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS diagnostics_session_id
+                ON diagnostics(session, id);
+            CREATE TABLE IF NOT EXISTS checkpoints (
+                session TEXT PRIMARY KEY,
+                call_id INTEGER NOT NULL CHECK(call_id >= 0)
+            );
+            """
+        )
+        row = self._connection.execute(
+            "SELECT value FROM metadata WHERE key = 'schema_version'"
+        ).fetchone()
+        if row is None:
+            self._connection.execute(
+                "INSERT INTO metadata (key, value) VALUES ('schema_version', ?)",
+                (str(SCHEMA_VERSION),),
+            )
+        elif row[0] != str(SCHEMA_VERSION):
+            raise LedgerError(f"unsupported SQLite ledger schema: {row[0]!r}")
+
+    def _enforce_capacity(
+        self,
+        session: str,
+        *,
+        max_sessions: int,
+        max_calls_per_session: int,
+    ) -> None:
+        self._enforce_session_capacity(session, max_sessions)
+        count = self._connection.execute(
+            "SELECT COUNT(*) FROM calls WHERE session = ?",
+            (session,),
+        ).fetchone()[0]
+        if count >= max_calls_per_session:
+            raise LedgerError("per-session SQLite call capacity reached")
+
+    def _enforce_session_capacity(self, session: str, max_sessions: int) -> None:
+        exists = self._connection.execute(
+            """
+            SELECT 1 FROM calls WHERE session = ?
+            UNION ALL SELECT 1 FROM diagnostics WHERE session = ? LIMIT 1
+            """,
+            (session, session),
+        ).fetchone()
+        if exists is not None:
+            return
+        count = self._connection.execute(
+            """
+            SELECT COUNT(*) FROM (
+                SELECT session FROM calls UNION SELECT session FROM diagnostics
+            )
+            """
+        ).fetchone()[0]
+        if count >= max_sessions:
+            raise LedgerError("SQLite session capacity reached")
+
+    @staticmethod
+    def _call_payload(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "model": row["model"],
+            "prompt_tokens": row["prompt_tokens"],
+            "completion_tokens": row["completion_tokens"],
+            "cached_tokens": row["cached_tokens"],
+            "cost": {
+                "prompt_cost_uncached": row["prompt_cost_uncached"],
+                "prompt_cost_cached": row["prompt_cost_cached"],
+                "completion_cost": row["completion_cost"],
+                "total_cost": row["total_cost"],
+            },
+            "timestamp": row["timestamp"],
+        }
+
+    def _rollback(self) -> None:
+        try:
+            self._connection.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass

--- a/openai_cost_calculator/proxy/ledger.py
+++ b/openai_cost_calculator/proxy/ledger.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+
+
+class LedgerError(RuntimeError):
+    """Raised when a durable ledger cannot be opened, validated, or written."""
+
+
+class DurableLedger:
+    """Single-process atomic JSON storage for proxy accounting state."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path).expanduser()
+        self.lock_path = self.path.with_name(f"{self.path.name}.lock")
+        self._lock_handle = None
+        self._acquire_lock()
+        self._cleanup_temporary_files()
+
+    def load(self) -> dict[str, Any]:
+        try:
+            text = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {"schema_version": SCHEMA_VERSION, "sessions": {}}
+        except OSError as exc:
+            raise LedgerError(f"cannot read durable ledger: {exc}") from exc
+
+        try:
+            payload = json.loads(text)
+        except (TypeError, ValueError) as exc:
+            raise LedgerError("durable ledger is not valid JSON") from exc
+        if not isinstance(payload, dict):
+            raise LedgerError("durable ledger root must be a JSON object")
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            raise LedgerError(
+                f"unsupported durable ledger schema: {payload.get('schema_version')!r}"
+            )
+        if not isinstance(payload.get("sessions"), dict):
+            raise LedgerError("durable ledger sessions must be a JSON object")
+        return payload
+
+    def save(self, payload: dict[str, Any]) -> None:
+        if self.path.is_symlink():
+            raise LedgerError("refusing to replace a symlinked durable ledger")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                temporary_path = Path(handle.name)
+                json.dump(payload, handle, separators=(",", ":"), sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            temporary_path.chmod(0o600)
+            os.replace(temporary_path, self.path)
+            self._fsync_directory()
+        except (OSError, TypeError, ValueError) as exc:
+            raise LedgerError(f"cannot write durable ledger: {exc}") from exc
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+
+    def close(self) -> None:
+        if self._lock_handle is None:
+            return
+        try:
+            import fcntl
+
+            fcntl.flock(self._lock_handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._lock_handle.close()
+            self._lock_handle = None
+
+    def _acquire_lock(self) -> None:
+        try:
+            import fcntl
+        except ImportError as exc:  # pragma: no cover - non-POSIX platforms
+            raise LedgerError("durable ledgers currently require POSIX file locking") from exc
+
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self.lock_path.open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            handle.close()
+            raise LedgerError(
+                "durable ledger is already in use by another proxy process"
+            ) from exc
+        self._lock_handle = handle
+
+    def _cleanup_temporary_files(self) -> None:
+        pattern = f".{self.path.name}.*.tmp"
+        for temporary_path in self.path.parent.glob(pattern):
+            try:
+                temporary_path.unlink()
+            except OSError:
+                pass
+
+    def _fsync_directory(self) -> None:
+        try:
+            descriptor = os.open(self.path.parent, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 import asyncio
 from decimal import Decimal
+import re
 from threading import RLock
 import time
 from typing import Dict, Iterable, Optional
 
 from openai_cost_calculator.tracker import CallRecord, CostTracker
+
+
+_MAX_ERRORS_PER_SESSION = 100
+_MAX_DIAGNOSTIC_LENGTH = 500
+_SECRET_RE = re.compile(
+    r"(?i)(?:bearer\s+)[^\s,;]+|(?:sk-[a-z0-9_-]{8,})"
+)
 
 
 class TrackerRegistry:
@@ -60,12 +68,14 @@ class TrackerRegistry:
     def record_error(self, session_id: Optional[str], code: str, message: str) -> None:
         key = session_id or "default"
         error = {
-            "code": code,
-            "message": message,
+            "code": _diagnostic_text(code, limit=64),
+            "message": _diagnostic_text(message),
             "timestamp": time.time(),
         }
         with self._lock:
-            self._errors.setdefault(key, []).append(error)
+            errors = self._errors.setdefault(key, [])
+            errors.append(error)
+            del errors[:-_MAX_ERRORS_PER_SESSION]
         if self._on_error is not None:
             self._on_error(RuntimeError(f"{code}: {message}"))
         self.notify()
@@ -78,7 +88,7 @@ class TrackerRegistry:
         self.notify()
 
     def subscribe(self) -> asyncio.Queue:
-        queue: asyncio.Queue = asyncio.Queue()
+        queue: asyncio.Queue = asyncio.Queue(maxsize=1)
         with self._lock:
             self._subscribers.append(queue)
         return queue
@@ -93,6 +103,11 @@ class TrackerRegistry:
         with self._lock:
             subscribers = list(self._subscribers)
         for queue in subscribers:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
             queue.put_nowait(summary)
 
     def summary(self, session_id: Optional[str] = None) -> dict:
@@ -199,3 +214,10 @@ def _records_summary(session_id: str, records: Iterable[CallRecord]) -> dict:
 
 
 default_registry = TrackerRegistry()
+
+
+def _diagnostic_text(value: object, *, limit: int = _MAX_DIAGNOSTIC_LENGTH) -> str:
+    text = str(value).replace("\r", " ").replace("\n", " ")
+    text = "".join(character if character.isprintable() else "?" for character in text)
+    text = _SECRET_RE.sub("[REDACTED]", text)
+    return text[:limit]

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Iterable, Optional
 
 from openai_cost_calculator.tracker import CallRecord, CostTracker
 from openai_cost_calculator.types import CostBreakdown
-from openai_cost_calculator.proxy.ledger import DurableLedger, LedgerError
+from openai_cost_calculator.proxy.ledger import DurableLedger, LedgerError, SQLiteLedger
 
 
 _MAX_ERRORS_PER_SESSION = 100
@@ -23,7 +23,15 @@ _SECRET_RE = re.compile(
 
 
 class TrackerRegistry:
-    def __init__(self, on_error=None, *, ledger_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        on_error=None,
+        *,
+        ledger_path: str | Path | None = None,
+        database_path: str | Path | None = None,
+    ) -> None:
+        if ledger_path is not None and database_path is not None:
+            raise ValueError("pass either ledger_path or database_path, not both")
         self._trackers: Dict[str, CostTracker] = {}
         self._checkpoint_cursors: Dict[str, int] = {}
         self._errors: Dict[str, list[dict]] = {}
@@ -31,7 +39,11 @@ class TrackerRegistry:
         self._subscribers: list[asyncio.Queue] = []
         self._lock = RLock()
         self._on_error = on_error
-        self._ledger = DurableLedger(ledger_path) if ledger_path is not None else None
+        self._ledger = (
+            SQLiteLedger(database_path)
+            if database_path is not None
+            else DurableLedger(ledger_path) if ledger_path is not None else None
+        )
         self._ledger_healthy = True
         self._ledger_error: Optional[str] = None
         if self._ledger is not None:
@@ -86,7 +98,7 @@ class TrackerRegistry:
                 turn_label=turn_label,
             )
             if record is not None:
-                self._persist_locked()
+                self._persist_call_locked(key, turn_label, record)
         if record is not None:
             self.notify()
         elif tracker.session_total == Decimal("0") and not tracker.turns:
@@ -113,7 +125,20 @@ class TrackerRegistry:
             errors = self._errors.setdefault(key, [])
             errors.append(error)
             del errors[:-_MAX_ERRORS_PER_SESSION]
-            self._persist_locked()
+            if isinstance(self._ledger, SQLiteLedger):
+                try:
+                    self._ledger.append_error(
+                        key,
+                        error,
+                        max_sessions=_MAX_SESSIONS,
+                        max_errors=_MAX_ERRORS_PER_SESSION,
+                    )
+                except LedgerError as exc:
+                    self._mark_ledger_error(exc)
+                else:
+                    self._mark_ledger_healthy()
+            else:
+                self._persist_locked()
         if self._on_error is not None:
             self._on_error(RuntimeError(f"{code}: {message}"))
         self.notify()
@@ -122,10 +147,12 @@ class TrackerRegistry:
         with self._lock:
             if self._ledger is not None:
                 try:
-                    self._ledger.save({"schema_version": 1, "sessions": {}})
+                    if isinstance(self._ledger, SQLiteLedger):
+                        self._ledger.reset()
+                    else:
+                        self._ledger.save({"schema_version": 1, "sessions": {}})
                 except LedgerError as exc:
-                    self._ledger_healthy = False
-                    self._ledger_error = _diagnostic_text(exc)
+                    self._mark_ledger_error(exc)
                     raise
             self._trackers.clear()
             self._checkpoint_cursors.clear()
@@ -147,9 +174,11 @@ class TrackerRegistry:
                 self._subscribers.remove(queue)
 
     def notify(self) -> None:
-        summary = self.summary()
         with self._lock:
             subscribers = list(self._subscribers)
+        if not subscribers:
+            return
+        summary = self.summary()
         for queue in subscribers:
             if queue.full():
                 try:
@@ -160,6 +189,7 @@ class TrackerRegistry:
 
     def summary(self, session_id: Optional[str] = None) -> dict:
         with self._lock:
+            self._refresh_sqlite_locked()
             if session_id is None:
                 trackers = dict(self._trackers)
                 errors = {key: list(value) for key, value in self._errors.items()}
@@ -193,6 +223,17 @@ class TrackerRegistry:
     def checkpoint(self, session_id: Optional[str]) -> dict:
         key = session_id or "default"
         with self._lock:
+            if isinstance(self._ledger, SQLiteLedger):
+                try:
+                    payloads = self._ledger.checkpoint(key)
+                except LedgerError as exc:
+                    self._mark_ledger_error(exc)
+                    raise
+                self._mark_ledger_healthy()
+                return _records_summary(
+                    key,
+                    [_record_from_payload(payload) for payload in payloads],
+                )
             tracker = self._trackers.get(key)
             records = _tracker_records(tracker) if tracker is not None else []
             cursor = min(self._checkpoint_cursors.get(key, 0), len(records))
@@ -207,12 +248,22 @@ class TrackerRegistry:
         return _records_summary(key, new_records)
 
     def persistence_status(self) -> dict:
+        backend = (
+            "sqlite"
+            if isinstance(self._ledger, SQLiteLedger)
+            else "json" if isinstance(self._ledger, DurableLedger) else None
+        )
         return {
             "enabled": self._ledger is not None,
             "path": str(self._ledger.path) if self._ledger is not None else None,
             "healthy": self._ledger_healthy,
             "error": self._ledger_error,
-            "concurrency": "single-proxy" if self._ledger is not None else None,
+            "backend": backend,
+            "concurrency": (
+                "multi-proxy"
+                if isinstance(self._ledger, SQLiteLedger)
+                else "single-proxy" if self._ledger is not None else None
+            ),
         }
 
     def close(self) -> None:
@@ -225,12 +276,55 @@ class TrackerRegistry:
         try:
             self._ledger.save(self._snapshot_locked())
         except LedgerError as exc:
-            self._ledger_healthy = False
-            self._ledger_error = _diagnostic_text(exc)
+            self._mark_ledger_error(exc)
             return False
+        self._mark_ledger_healthy()
+        return True
+
+    def _persist_call_locked(
+        self,
+        session: str,
+        turn_label: Optional[str],
+        record: CallRecord,
+    ) -> bool:
+        if not isinstance(self._ledger, SQLiteLedger):
+            return self._persist_locked()
+        try:
+            self._ledger.append_call(
+                session,
+                turn_label,
+                _record_payload(record),
+                max_sessions=_MAX_SESSIONS,
+                max_calls_per_session=_MAX_CALLS_PER_SESSION,
+            )
+        except LedgerError as exc:
+            self._mark_ledger_error(exc)
+            return False
+        self._mark_ledger_healthy()
+        return True
+
+    def _refresh_sqlite_locked(self) -> None:
+        if not isinstance(self._ledger, SQLiteLedger) or not self._ledger_healthy:
+            return
+        try:
+            payload = self._ledger.load()
+        except LedgerError as exc:
+            self._mark_ledger_error(exc)
+            return
+        initial_totals = dict(self._initial_totals)
+        self._trackers.clear()
+        self._checkpoint_cursors.clear()
+        self._errors.clear()
+        self._restore(payload, set_initial=False)
+        self._initial_totals = initial_totals
+
+    def _mark_ledger_error(self, exc: Exception) -> None:
+        self._ledger_healthy = False
+        self._ledger_error = _diagnostic_text(exc)
+
+    def _mark_ledger_healthy(self) -> None:
         self._ledger_healthy = True
         self._ledger_error = None
-        return True
 
     def _snapshot_locked(self) -> dict[str, Any]:
         sessions: dict[str, Any] = {}
@@ -252,7 +346,7 @@ class TrackerRegistry:
             }
         return {"schema_version": 1, "sessions": sessions}
 
-    def _restore(self, payload: dict[str, Any]) -> None:
+    def _restore(self, payload: dict[str, Any], *, set_initial: bool = True) -> None:
         try:
             sessions = payload["sessions"]
             if len(sessions) > _MAX_SESSIONS + 1:
@@ -294,7 +388,8 @@ class TrackerRegistry:
                 self._checkpoint_cursors[key] = min(
                     cursor, len(_tracker_records(tracker))
                 )
-                self._initial_totals[key] = tracker.session_total
+                if set_initial:
+                    self._initial_totals[key] = tracker.session_total
         except (KeyError, TypeError, ValueError) as exc:
             raise LedgerError(f"durable ledger has invalid accounting data: {exc}") from exc
 

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -46,7 +46,11 @@ class TrackerRegistry:
         )
         self._ledger_healthy = True
         self._ledger_error: Optional[str] = None
-        if self._ledger is not None:
+        self._sqlite_generation: Optional[int] = None
+        if isinstance(self._ledger, SQLiteLedger):
+            self._initial_totals = self._ledger.totals()
+            self._sqlite_generation = self._ledger.generation()
+        elif self._ledger is not None:
             self._restore(self._ledger.load())
 
     def get(self, session_id: Optional[str]) -> CostTracker:
@@ -85,7 +89,10 @@ class TrackerRegistry:
             )
             return None
         with self._lock:
-            if len(_tracker_records(tracker)) >= _MAX_CALLS_PER_SESSION:
+            if (
+                not isinstance(self._ledger, SQLiteLedger)
+                and len(_tracker_records(tracker)) >= _MAX_CALLS_PER_SESSION
+            ):
                 self.record_error(
                     key,
                     "accounting_capacity_reached",
@@ -158,6 +165,8 @@ class TrackerRegistry:
             self._checkpoint_cursors.clear()
             self._errors.clear()
             self._initial_totals.clear()
+            if isinstance(self._ledger, SQLiteLedger):
+                self._sqlite_generation = self._ledger.generation()
             self._ledger_healthy = True
             self._ledger_error = None
         self.notify()
@@ -189,7 +198,14 @@ class TrackerRegistry:
 
     def summary(self, session_id: Optional[str] = None) -> dict:
         with self._lock:
-            self._refresh_sqlite_locked()
+            if isinstance(self._ledger, SQLiteLedger) and self._ledger_healthy:
+                generation = self._ledger.generation()
+                if generation != self._sqlite_generation:
+                    self._initial_totals = self._ledger.totals()
+                    self._sqlite_generation = generation
+                summary = self._ledger.summary(session_id, self._initial_totals)
+                summary["persistence"] = self.persistence_status()
+                return summary
             if session_id is None:
                 trackers = dict(self._trackers)
                 errors = {key: list(value) for key, value in self._errors.items()}
@@ -225,15 +241,12 @@ class TrackerRegistry:
         with self._lock:
             if isinstance(self._ledger, SQLiteLedger):
                 try:
-                    payloads = self._ledger.checkpoint(key)
+                    payload = self._ledger.checkpoint(key)
                 except LedgerError as exc:
                     self._mark_ledger_error(exc)
                     raise
                 self._mark_ledger_healthy()
-                return _records_summary(
-                    key,
-                    [_record_from_payload(payload) for payload in payloads],
-                )
+                return payload
             tracker = self._trackers.get(key)
             records = _tracker_records(tracker) if tracker is not None else []
             cursor = min(self._checkpoint_cursors.get(key, 0), len(records))
@@ -295,28 +308,13 @@ class TrackerRegistry:
                 turn_label,
                 _record_payload(record),
                 max_sessions=_MAX_SESSIONS,
-                max_calls_per_session=_MAX_CALLS_PER_SESSION,
+                max_calls_per_session=None,
             )
         except LedgerError as exc:
             self._mark_ledger_error(exc)
             return False
         self._mark_ledger_healthy()
         return True
-
-    def _refresh_sqlite_locked(self) -> None:
-        if not isinstance(self._ledger, SQLiteLedger) or not self._ledger_healthy:
-            return
-        try:
-            payload = self._ledger.load()
-        except LedgerError as exc:
-            self._mark_ledger_error(exc)
-            return
-        initial_totals = dict(self._initial_totals)
-        self._trackers.clear()
-        self._checkpoint_cursors.clear()
-        self._errors.clear()
-        self._restore(payload, set_initial=False)
-        self._initial_totals = initial_totals
 
     def _mark_ledger_error(self, exc: Exception) -> None:
         self._ledger_healthy = False

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -5,9 +5,12 @@ from decimal import Decimal
 import re
 from threading import RLock
 import time
-from typing import Dict, Iterable, Optional
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
 
 from openai_cost_calculator.tracker import CallRecord, CostTracker
+from openai_cost_calculator.types import CostBreakdown
+from openai_cost_calculator.proxy.ledger import DurableLedger, LedgerError
 
 
 _MAX_ERRORS_PER_SESSION = 100
@@ -18,13 +21,19 @@ _SECRET_RE = re.compile(
 
 
 class TrackerRegistry:
-    def __init__(self, on_error=None) -> None:
+    def __init__(self, on_error=None, *, ledger_path: str | Path | None = None) -> None:
         self._trackers: Dict[str, CostTracker] = {}
         self._checkpoint_cursors: Dict[str, int] = {}
         self._errors: Dict[str, list[dict]] = {}
+        self._initial_totals: Dict[str, Decimal] = {}
         self._subscribers: list[asyncio.Queue] = []
         self._lock = RLock()
         self._on_error = on_error
+        self._ledger = DurableLedger(ledger_path) if ledger_path is not None else None
+        self._ledger_healthy = True
+        self._ledger_error: Optional[str] = None
+        if self._ledger is not None:
+            self._restore(self._ledger.load())
 
     def get(self, session_id: Optional[str]) -> CostTracker:
         key = session_id or "default"
@@ -57,6 +66,8 @@ class TrackerRegistry:
                 usage,
                 turn_label=turn_label,
             )
+            if record is not None:
+                self._persist_locked()
         if record is not None:
             self.notify()
         elif tracker.session_total == Decimal("0") and not tracker.turns:
@@ -76,15 +87,26 @@ class TrackerRegistry:
             errors = self._errors.setdefault(key, [])
             errors.append(error)
             del errors[:-_MAX_ERRORS_PER_SESSION]
+            self._persist_locked()
         if self._on_error is not None:
             self._on_error(RuntimeError(f"{code}: {message}"))
         self.notify()
 
     def reset(self) -> None:
         with self._lock:
+            if self._ledger is not None:
+                try:
+                    self._ledger.save({"schema_version": 1, "sessions": {}})
+                except LedgerError as exc:
+                    self._ledger_healthy = False
+                    self._ledger_error = _diagnostic_text(exc)
+                    raise
             self._trackers.clear()
             self._checkpoint_cursors.clear()
             self._errors.clear()
+            self._initial_totals.clear()
+            self._ledger_healthy = True
+            self._ledger_error = None
         self.notify()
 
     def subscribe(self) -> asyncio.Queue:
@@ -129,13 +151,17 @@ class TrackerRegistry:
             grand_total += session_total
             sessions[current_session] = {
                 "session_total": f"{session_total:.8f}",
+                "historical_total": f"{self._initial_totals.get(current_session, Decimal('0')):.8f}",
+                "process_total": f"{(session_total - self._initial_totals.get(current_session, Decimal('0'))):.8f}",
                 "turns": [turn.as_dict() for turn in tracker.turns] if tracker is not None else [],
                 "errors": errors.get(current_session, []),
+                "latest_call": _latest_call(tracker),
             }
 
         return {
             "sessions": sessions,
             "grand_total": f"{grand_total:.8f}",
+            "persistence": self.persistence_status(),
         }
 
     def checkpoint(self, session_id: Optional[str]) -> dict:
@@ -146,8 +172,101 @@ class TrackerRegistry:
             cursor = min(self._checkpoint_cursors.get(key, 0), len(records))
             new_records = records[cursor:]
             self._checkpoint_cursors[key] = len(records)
+            if not self._persist_locked():
+                self._checkpoint_cursors[key] = cursor
+                raise LedgerError(
+                    "checkpoint was not consumed because the durable ledger write failed"
+                )
 
         return _records_summary(key, new_records)
+
+    def persistence_status(self) -> dict:
+        return {
+            "enabled": self._ledger is not None,
+            "path": str(self._ledger.path) if self._ledger is not None else None,
+            "healthy": self._ledger_healthy,
+            "error": self._ledger_error,
+            "concurrency": "single-proxy" if self._ledger is not None else None,
+        }
+
+    def close(self) -> None:
+        if self._ledger is not None:
+            self._ledger.close()
+
+    def _persist_locked(self) -> bool:
+        if self._ledger is None:
+            return True
+        try:
+            self._ledger.save(self._snapshot_locked())
+        except LedgerError as exc:
+            self._ledger_healthy = False
+            self._ledger_error = _diagnostic_text(exc)
+            return False
+        self._ledger_healthy = True
+        self._ledger_error = None
+        return True
+
+    def _snapshot_locked(self) -> dict[str, Any]:
+        sessions: dict[str, Any] = {}
+        for key in sorted(set(self._trackers) | set(self._errors)):
+            tracker = self._trackers.get(key)
+            turns = []
+            if tracker is not None:
+                for turn in tracker.turns:
+                    turns.append(
+                        {
+                            "label": turn.label,
+                            "records": [_record_payload(record) for record in turn.records],
+                        }
+                    )
+            sessions[key] = {
+                "turns": turns,
+                "errors": list(self._errors.get(key, [])),
+                "checkpoint_cursor": self._checkpoint_cursors.get(key, 0),
+            }
+        return {"schema_version": 1, "sessions": sessions}
+
+    def _restore(self, payload: dict[str, Any]) -> None:
+        try:
+            sessions = payload["sessions"]
+            for key, session in sessions.items():
+                if not isinstance(key, str) or not isinstance(session, dict):
+                    raise ValueError("invalid session entry")
+                tracker = CostTracker(
+                    on_error=lambda exc, session_key=key: self.record_error(
+                        session_key, "cost_estimation_failed", str(exc)
+                    )
+                )
+                for turn_payload in session.get("turns", []):
+                    if not isinstance(turn_payload, dict):
+                        raise ValueError("invalid turn entry")
+                    label = turn_payload.get("label")
+                    if label is not None and not isinstance(label, str):
+                        raise ValueError("invalid turn label")
+                    record_payloads = turn_payload.get("records", [])
+                    if not isinstance(record_payloads, list):
+                        raise ValueError("invalid turn records")
+                    tracker.restore_turn(
+                        [_record_from_payload(item) for item in record_payloads],
+                        label=label,
+                    )
+                errors = session.get("errors", [])
+                if not isinstance(errors, list) or not all(
+                    isinstance(error, dict) for error in errors
+                ):
+                    raise ValueError("invalid diagnostics entry")
+                cursor = session.get("checkpoint_cursor", 0)
+                if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
+                    raise ValueError("invalid checkpoint cursor")
+                if tracker.turns:
+                    self._trackers[key] = tracker
+                self._errors[key] = list(errors[-_MAX_ERRORS_PER_SESSION:])
+                self._checkpoint_cursors[key] = min(
+                    cursor, len(_tracker_records(tracker))
+                )
+                self._initial_totals[key] = tracker.session_total
+        except (KeyError, TypeError, ValueError) as exc:
+            raise LedgerError(f"durable ledger has invalid accounting data: {exc}") from exc
 
 
 def _tracker_records(tracker: Optional[CostTracker]) -> list[CallRecord]:
@@ -211,6 +330,60 @@ def _records_summary(session_id: str, records: Iterable[CallRecord]) -> dict:
             for model_name, model in stringified_models.items()
         },
     }
+
+
+def _record_payload(record: CallRecord) -> dict[str, Any]:
+    return {
+        "model": record.model,
+        "prompt_tokens": record.prompt_tokens,
+        "completion_tokens": record.completion_tokens,
+        "cached_tokens": record.cached_tokens,
+        "cost": record.cost.as_dict(stringify=True),
+        "timestamp": record.timestamp,
+    }
+
+
+def _record_from_payload(payload: Any) -> CallRecord:
+    if not isinstance(payload, dict):
+        raise ValueError("invalid call record")
+    model = payload.get("model")
+    timestamp = payload.get("timestamp")
+    if not isinstance(model, str) or not isinstance(timestamp, (int, float)):
+        raise ValueError("invalid call record identity")
+    token_values = {}
+    for key in ("prompt_tokens", "completion_tokens", "cached_tokens"):
+        value = payload.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"invalid call record {key}")
+        token_values[key] = value
+    cost = payload.get("cost")
+    if not isinstance(cost, dict):
+        raise ValueError("invalid call record cost")
+    try:
+        breakdown = CostBreakdown(
+            prompt_cost_uncached=Decimal(cost["prompt_cost_uncached"]),
+            prompt_cost_cached=Decimal(cost["prompt_cost_cached"]),
+            completion_cost=Decimal(cost["completion_cost"]),
+            total_cost=Decimal(cost["total_cost"]),
+        )
+    except Exception as exc:
+        raise ValueError("invalid call record cost") from exc
+    if any(value < 0 or not value.is_finite() for value in breakdown.as_dict(False).values()):
+        raise ValueError("invalid call record cost")
+    if breakdown.total_cost != (
+        breakdown.prompt_cost_uncached
+        + breakdown.prompt_cost_cached
+        + breakdown.completion_cost
+    ):
+        raise ValueError("call record cost components do not equal total")
+    return CallRecord(cost=breakdown, timestamp=float(timestamp), model=model, **token_values)
+
+
+def _latest_call(tracker: Optional[CostTracker]) -> Optional[dict[str, Any]]:
+    records = _tracker_records(tracker)
+    if not records:
+        return None
+    return _record_payload(records[-1])
 
 
 default_registry = TrackerRegistry()

--- a/openai_cost_calculator/proxy/registry.py
+++ b/openai_cost_calculator/proxy/registry.py
@@ -15,6 +15,8 @@ from openai_cost_calculator.proxy.ledger import DurableLedger, LedgerError
 
 _MAX_ERRORS_PER_SESSION = 100
 _MAX_DIAGNOSTIC_LENGTH = 500
+_MAX_SESSIONS = 1_024
+_MAX_CALLS_PER_SESSION = 50_000
 _SECRET_RE = re.compile(
     r"(?i)(?:bearer\s+)[^\s,;]+|(?:sk-[a-z0-9_-]{8,})"
 )
@@ -40,6 +42,8 @@ class TrackerRegistry:
         with self._lock:
             tracker = self._trackers.get(key)
             if tracker is None:
+                if len(set(self._trackers) | set(self._errors)) >= _MAX_SESSIONS:
+                    raise RegistryCapacityError("accounting session capacity reached")
                 tracker = CostTracker(
                     on_error=lambda exc: self.record_error(
                         key,
@@ -59,8 +63,23 @@ class TrackerRegistry:
         turn_label: Optional[str] = None,
     ) -> Optional[CallRecord]:
         key = session_id or "default"
-        tracker = self.get(key)
+        try:
+            tracker = self.get(key)
+        except RegistryCapacityError:
+            self.record_error(
+                "__registry__",
+                "accounting_capacity_reached",
+                "additional session was not recorded because the registry session limit was reached",
+            )
+            return None
         with self._lock:
+            if len(_tracker_records(tracker)) >= _MAX_CALLS_PER_SESSION:
+                self.record_error(
+                    key,
+                    "accounting_capacity_reached",
+                    "call was not recorded because the per-session call limit was reached",
+                )
+                return None
             record = tracker.record_call(
                 model,
                 usage,
@@ -78,6 +97,13 @@ class TrackerRegistry:
 
     def record_error(self, session_id: Optional[str], code: str, message: str) -> None:
         key = session_id or "default"
+        with self._lock:
+            if (
+                key not in self._trackers
+                and key not in self._errors
+                and len(set(self._trackers) | set(self._errors)) >= _MAX_SESSIONS
+            ):
+                key = "__registry__"
         error = {
             "code": _diagnostic_text(code, limit=64),
             "message": _diagnostic_text(message),
@@ -229,6 +255,8 @@ class TrackerRegistry:
     def _restore(self, payload: dict[str, Any]) -> None:
         try:
             sessions = payload["sessions"]
+            if len(sessions) > _MAX_SESSIONS + 1:
+                raise ValueError("ledger exceeds supported session capacity")
             for key, session in sessions.items():
                 if not isinstance(key, str) or not isinstance(session, dict):
                     raise ValueError("invalid session entry")
@@ -259,6 +287,8 @@ class TrackerRegistry:
                 if not isinstance(cursor, int) or isinstance(cursor, bool) or cursor < 0:
                     raise ValueError("invalid checkpoint cursor")
                 if tracker.turns:
+                    if len(_tracker_records(tracker)) > _MAX_CALLS_PER_SESSION:
+                        raise ValueError("session exceeds supported call capacity")
                     self._trackers[key] = tracker
                 self._errors[key] = list(errors[-_MAX_ERRORS_PER_SESSION:])
                 self._checkpoint_cursors[key] = min(
@@ -387,6 +417,10 @@ def _latest_call(tracker: Optional[CostTracker]) -> Optional[dict[str, Any]]:
 
 
 default_registry = TrackerRegistry()
+
+
+class RegistryCapacityError(RuntimeError):
+    """Raised internally when bounded accounting state reaches capacity."""
 
 
 def _diagnostic_text(value: object, *, limit: int = _MAX_DIAGNOSTIC_LENGTH) -> str:

--- a/openai_cost_calculator/proxy/upstreams.py
+++ b/openai_cost_calculator/proxy/upstreams.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+
+PLATFORM_UPSTREAM = "https://api.openai.com/v1"
+CHATGPT_CODEX_UPSTREAM = "https://chatgpt.com/backend-api/codex"
+AUTH_MODES = {"auto", "api-key", "chatgpt"}
+
+
+class UpstreamSelectionError(ValueError):
+    """Raised when authentication and upstream settings are ambiguous or incompatible."""
+
+
+@dataclass(frozen=True)
+class UpstreamSelection:
+    auth_mode: str
+    category: str
+    url: str
+    explicit_override: bool
+    detection_source: str
+
+
+def resolve_upstream(
+    *,
+    auth_mode: str = "auto",
+    upstream: Optional[str] = None,
+    codex_home: str | Path | None = None,
+) -> UpstreamSelection:
+    if auth_mode not in AUTH_MODES:
+        raise UpstreamSelectionError(
+            f"authentication mode must be one of: {', '.join(sorted(AUTH_MODES))}"
+        )
+
+    selected_mode = auth_mode
+    source = "explicit CLI option"
+    if auth_mode == "auto":
+        detected, source = detect_codex_auth_mode(codex_home)
+        selected_mode = detected or "unspecified"
+
+    explicit_override = upstream is not None
+    if upstream is None:
+        upstream = (
+            CHATGPT_CODEX_UPSTREAM
+            if selected_mode == "chatgpt"
+            else PLATFORM_UPSTREAM
+        )
+    normalized = _normalize_upstream(upstream)
+    category = classify_upstream(normalized)
+
+    if selected_mode == "chatgpt" and category == "platform":
+        raise UpstreamSelectionError(
+            "ChatGPT-backed Codex authentication is incompatible with the Platform API upstream"
+        )
+    if selected_mode == "api-key" and category == "chatgpt-codex":
+        raise UpstreamSelectionError(
+            "Platform API-key authentication is incompatible with the ChatGPT Codex upstream"
+        )
+
+    return UpstreamSelection(
+        auth_mode=selected_mode,
+        category=category,
+        url=normalized,
+        explicit_override=explicit_override,
+        detection_source=source,
+    )
+
+
+def detect_codex_auth_mode(
+    codex_home: str | Path | None = None,
+) -> tuple[Optional[str], str]:
+    home = Path(codex_home) if codex_home is not None else Path(
+        os.environ.get("CODEX_HOME") or Path.home() / ".codex"
+    )
+    auth_path = home / "auth.json"
+    try:
+        payload = json.loads(auth_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        payload = None
+    except (OSError, ValueError) as exc:
+        raise UpstreamSelectionError(
+            f"cannot determine Codex authentication mode from {auth_path}: invalid auth metadata"
+        ) from exc
+
+    if isinstance(payload, dict):
+        mode = payload.get("auth_mode")
+        if mode == "api":
+            return "api-key", "Codex auth metadata"
+        if mode == "chatgpt":
+            return "chatgpt", "Codex auth metadata"
+        raise UpstreamSelectionError(
+            "Codex auth metadata has an unsupported or missing authentication mode"
+        )
+    if os.environ.get("OPENAI_API_KEY"):
+        return "api-key", "OPENAI_API_KEY environment presence"
+    return None, "no Codex authentication metadata found"
+
+
+def classify_upstream(url: str) -> str:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.rstrip("/")
+    if host == "api.openai.com" and path == "/v1":
+        return "platform"
+    if host == "chatgpt.com" and path == "/backend-api/codex":
+        return "chatgpt-codex"
+    return "custom"
+
+
+def _normalize_upstream(value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise UpstreamSelectionError("upstream override must be a non-empty HTTP(S) URL")
+    normalized = value.strip().rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise UpstreamSelectionError("upstream override must be an HTTP(S) URL")
+    if parsed.username is not None or parsed.password is not None:
+        raise UpstreamSelectionError("upstream override must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise UpstreamSelectionError("upstream override must not contain a query or fragment")
+    return normalized

--- a/openai_cost_calculator/tracker.py
+++ b/openai_cost_calculator/tracker.py
@@ -218,6 +218,14 @@ class CostTracker:
         self.session_total = Decimal("0")
         self._active_turn = None
 
+    def restore_turn(self, records: List[CallRecord], *, label: Optional[str]) -> None:
+        """Restore one previously costed turn without repricing its calls."""
+        turn = Turn(label)
+        for record in records:
+            turn.add(record)
+            self.session_total += record.cost.total_cost
+        self.turns.append(turn)
+
     def _find_or_create_turn(self, label: Optional[str]) -> Turn:
         for turn in self.turns:
             if turn.label == label:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ proxy = [
     "fastapi",
     "httpx",
     "uvicorn",
+    "websockets>=13",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==8.3.5
 requests
 fastapi
 httpx
+websockets>=13

--- a/scripts/self_test_codex_integration.py
+++ b/scripts/self_test_codex_integration.py
@@ -373,7 +373,7 @@ def _validate_install(path: Path, proxy_url: str, session: str) -> None:
         "base_url": f"{proxy_url}/v1",
         "requires_openai_auth": True,
         "wire_api": "responses",
-        "supports_websockets": False,
+        "supports_websockets": True,
         "http_headers": {"X-OCC-Session": session},
     }
     for key, value in expected.items():

--- a/scripts/self_test_codex_integration.py
+++ b/scripts/self_test_codex_integration.py
@@ -42,6 +42,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int)
     parser.add_argument("--session")
     parser.add_argument(
+        "--auth-mode",
+        choices=["auto", "chatgpt", "api-key"],
+        default="auto",
+        help="Authentication path to exercise (default: auto-detect source login)",
+    )
+    parser.add_argument(
         "--upstream",
         help="Proxy upstream; defaults from the isolated Codex login mode.",
     )
@@ -64,7 +70,11 @@ def main() -> int:
     try:
         codex_home = temp_root / "codex-home"
         codex_home.mkdir(mode=0o700)
-        auth_method, auth_mode = _prepare_auth(codex_home, Path(args.codex))
+        auth_method, auth_mode = _prepare_auth(
+            codex_home,
+            Path(args.codex),
+            requested_mode=args.auth_mode,
+        )
         model = args.model or _source_codex_model()
         env = _isolated_env(codex_home)
         proxy_url = f"http://127.0.0.1:{port}"
@@ -107,7 +117,7 @@ def main() -> int:
             "--port",
             str(port),
             "--auth-mode",
-            "api-key" if auth_mode == "api" else auth_mode,
+            auth_mode,
         ]
         if args.upstream:
             proxy_command.extend(["--upstream", args.upstream])
@@ -270,22 +280,49 @@ def main() -> int:
             print(f"Temporary files retained at {temp_root}", file=sys.stderr)
 
 
-def _prepare_auth(codex_home: Path, codex: Path) -> tuple[str, str]:
+def _prepare_auth(
+    codex_home: Path,
+    codex: Path,
+    *,
+    requested_mode: str = "auto",
+) -> tuple[str, str]:
     source_auth = Path.home() / ".codex" / "auth.json"
+    source_mode = None
     if source_auth.is_file():
         try:
-            auth_mode = json.loads(source_auth.read_text(encoding="utf-8")).get("auth_mode")
+            source_mode = json.loads(
+                source_auth.read_text(encoding="utf-8")
+            ).get("auth_mode")
         except (OSError, ValueError):
-            auth_mode = None
-        if auth_mode not in {"chatgpt", "api"}:
+            source_mode = None
+        if source_mode not in {"chatgpt", "api"}:
             raise SelfTestError("existing Codex auth.json has an unsupported or missing auth_mode")
+
+    use_source = requested_mode == "chatgpt" or (
+        requested_mode == "auto" and source_mode is not None
+    )
+    if use_source:
+        if source_mode != "chatgpt" and requested_mode == "chatgpt":
+            raise SelfTestError(
+                "--auth-mode chatgpt requires an existing ChatGPT-backed Codex login"
+            )
+        if source_mode is None:
+            raise SelfTestError(
+                "--auth-mode chatgpt requires an existing ChatGPT-backed Codex login"
+            )
         destination = codex_home / "auth.json"
         shutil.copy2(source_auth, destination)
         destination.chmod(0o600)
-        return "isolated copy of existing Codex login", auth_mode
+        return "isolated copy of existing Codex login", (
+            "api-key" if source_mode == "api" else "chatgpt"
+        )
 
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
+        if requested_mode == "api-key":
+            raise SelfTestError(
+                "--auth-mode api-key requires OPENAI_API_KEY in the environment"
+            )
         raise SelfTestError(
             "no ~/.codex/auth.json or OPENAI_API_KEY is available for isolated Codex authentication"
         )
@@ -301,7 +338,7 @@ def _prepare_auth(codex_home: Path, codex: Path) -> tuple[str, str]:
     )
     if login.returncode != 0:
         raise SelfTestError("Codex API-key login failed in the isolated home")
-    return "OPENAI_API_KEY imported into isolated Codex login", "api"
+    return "OPENAI_API_KEY imported into isolated Codex login", "api-key"
 
 
 def _source_codex_model() -> str | None:

--- a/scripts/self_test_codex_integration.py
+++ b/scripts/self_test_codex_integration.py
@@ -66,7 +66,6 @@ def main() -> int:
         codex_home.mkdir(mode=0o700)
         auth_method, auth_mode = _prepare_auth(codex_home, Path(args.codex))
         model = args.model or _source_codex_model()
-        upstream = args.upstream or _default_upstream(auth_mode)
         env = _isolated_env(codex_home)
         proxy_url = f"http://127.0.0.1:{port}"
 
@@ -107,9 +106,11 @@ def main() -> int:
             "127.0.0.1",
             "--port",
             str(port),
-            "--upstream",
-            upstream,
+            "--auth-mode",
+            "api-key" if auth_mode == "api" else auth_mode,
         ]
+        if args.upstream:
+            proxy_command.extend(["--upstream", args.upstream])
         proxy = subprocess.Popen(
             proxy_command,
             cwd=ROOT,
@@ -121,7 +122,7 @@ def main() -> int:
         _wait_ready(proxy_url, proxy)
 
         baseline = _get_json(f"{proxy_url}/_occ/costs?{_query(session)}")
-        if baseline != {"sessions": {}, "grand_total": "0.00000000"}:
+        if baseline.get("sessions") != {} or baseline.get("grand_total") != "0.00000000":
             raise SelfTestError(f"unique session did not have a clean baseline: {baseline}")
 
         output_file = temp_root / "last-message.txt"
@@ -310,12 +311,6 @@ def _source_codex_model() -> str | None:
     except (OSError, tomllib.TOMLDecodeError):
         return None
     return model if isinstance(model, str) and model else None
-
-
-def _default_upstream(auth_mode: str) -> str:
-    if auth_mode == "chatgpt":
-        return "https://chatgpt.com/backend-api/codex"
-    return "https://api.openai.com/v1"
 
 
 def _isolated_env(codex_home: Path) -> dict[str, str]:

--- a/scripts/self_test_codex_integration.py
+++ b/scripts/self_test_codex_integration.py
@@ -13,13 +13,17 @@ import subprocess
 import sys
 import tempfile
 import time
-import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11
+    import tomli as tomllib  # type: ignore[no-redef]
 
 
 FIXED_RESPONSE = "OCC_SELF_TEST_OK"

--- a/scripts/self_test_codex_integration.py
+++ b/scripts/self_test_codex_integration.py
@@ -352,6 +352,8 @@ def _source_codex_model() -> str | None:
 
 def _isolated_env(codex_home: Path) -> dict[str, str]:
     env = dict(os.environ)
+    env.pop("OCC_ADMIN_TOKEN", None)
+    env.pop("OCC_ADMIN_TOKEN_FILE", None)
     env["CODEX_HOME"] = str(codex_home)
     env["PATH"] = f"{Path(sys.executable).parent}{os.pathsep}{env.get('PATH', '')}"
     return env

--- a/scripts/self_test_codex_integration.py
+++ b/scripts/self_test_codex_integration.py
@@ -373,7 +373,7 @@ def _validate_install(path: Path, proxy_url: str, session: str) -> None:
         "base_url": f"{proxy_url}/v1",
         "requires_openai_auth": True,
         "wire_api": "responses",
-        "supports_websockets": True,
+        "supports_websockets": False,
         "http_headers": {"X-OCC-Session": session},
     }
     for key, value in expected.items():

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     },
     install_requires=["requests", "tomli; python_version < '3.11'"],
     extras_require={
-        "proxy": ["fastapi", "httpx", "uvicorn"],
+        "proxy": ["fastapi", "httpx", "uvicorn", "websockets>=13"],
     },
     entry_points={
         "console_scripts": [

--- a/tests/asgi_client.py
+++ b/tests/asgi_client.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+
+
+class ASGITestClient:
+    """Small synchronous facade over httpx's non-deprecated ASGI transport."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    def request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        async def send() -> httpx.Response:
+            transport = httpx.ASGITransport(app=self.app)
+            async with httpx.AsyncClient(
+                transport=transport,
+                base_url="http://testserver",
+            ) as client:
+                return await client.request(method, path, **kwargs)
+
+        return asyncio.run(send())
+
+    def get(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.request("GET", path, **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> httpx.Response:
+        return self.request("POST", path, **kwargs)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -309,7 +309,7 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
     assert 'base_url = "http://127.0.0.1:8100/v1"' in text
     assert "requires_openai_auth = true" in text
     assert 'env_key = "OPENAI_API_KEY"' not in text
-    assert "supports_websockets = true" in text
+    assert "supports_websockets = false" in text
     assert 'http_headers = { "X-OCC-Session" = "s1" }' in text
     active_notify_lines = [
         line for line in text.splitlines() if line.startswith('notify = ["')
@@ -325,6 +325,19 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
         'model = "gpt-test"\n'
     )
     assert list(codex_dir.glob("*.occ-backup-*")) == []
+
+
+def test_codex_installer_can_enable_websockets_explicitly(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+
+    install_codex(
+        "http://127.0.0.1:8100",
+        "s1",
+        supports_websockets=True,
+    )
+
+    text = (tmp_path / "config.toml").read_text(encoding="utf-8")
+    assert "supports_websockets = true" in text
 
 
 def test_codex_installer_refuses_invalid_config_without_modifying_it(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import httpx
 import pytest
-from fastapi.testclient import TestClient
+
+from asgi_client import ASGITestClient
 
 from openai_cost_calculator.adapters.claude_code import (
     statusline_text as claude_statusline_text,
@@ -14,6 +15,7 @@ from openai_cost_calculator.adapters.claude_code import (
 )
 from openai_cost_calculator.adapters.codex import (
     checkpoint_text,
+    notifier_diagnostics,
     notify_main,
     statusline_text as codex_statusline_text,
 )
@@ -144,6 +146,33 @@ def test_codex_adapters_render_and_silently_handle_network_errors(monkeypatch):
     assert codex_statusline_text(session="s1") == "💰 cost offline"
 
 
+def test_codex_notifier_records_hidden_proxy_failure_without_failing_codex(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda request, timeout: (_ for _ in ()).throw(OSError("Bearer secret")),
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "occ-codex-notify",
+            json.dumps({"type": "agent-turn-complete"}),
+        ],
+    )
+
+    assert notify_main() == 0
+    assert capsys.readouterr().out == ""
+    diagnostics = notifier_diagnostics()
+    assert diagnostics[-1]["code"] == "checkpoint_unavailable"
+    assert "secret" not in diagnostics[-1]["message"]
+    log = tmp_path / "occ-notifier-diagnostics.jsonl"
+    assert log.stat().st_mode & 0o777 == 0o600
+
+
 def test_codex_notify_uses_installed_session_and_chains_previous_notifier(
     tmp_path: Path,
     monkeypatch,
@@ -227,7 +256,7 @@ def test_proxy_checkpoint_advances_cursor_and_costs_remain_cumulative():
         transport=httpx.MockTransport(handler),
         registry=TrackerRegistry(),
     )
-    client = TestClient(app)
+    client = ASGITestClient(app)
     for _ in range(2):
         client.post("/v1/responses", json={}, headers={"x-occ-session": "s1"})
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -14,6 +14,7 @@ from openai_cost_calculator.adapters.claude_code import (
     stop_hook_output,
 )
 from openai_cost_calculator.adapters.codex import (
+    _codex_adapter_settings,
     checkpoint_text,
     notifier_diagnostics,
     notify_main,
@@ -314,14 +315,14 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
         line for line in text.splitlines() if line.startswith('notify = ["')
     ]
     assert active_notify_lines == ['notify = ["occ-codex-notify"]']
-    assert "# previous_notify = notify = [\"existing-notifier\"]" in text
-    assert '# previous_model_provider = model_provider = "existing-provider"' in text
+    assert "# occ-restore-notify = " in text
+    assert "# occ-restore-model_provider = " in text
     assert 'model = "gpt-test"' in text
     uninstall_codex()
-    assert codex_config.read_text(encoding="utf-8").strip() == (
-        'model_provider = "existing-provider"\n'
+    assert codex_config.read_text(encoding="utf-8") == (
         'notify = ["existing-notifier"]\n'
-        'model = "gpt-test"'
+        'model_provider = "existing-provider"\n'
+        'model = "gpt-test"\n'
     )
     assert list(codex_dir.glob("*.occ-backup-*")) == []
 
@@ -402,3 +403,90 @@ def test_codex_atomic_write_failure_preserves_original_and_cleans_temp(
     assert config.read_text(encoding="utf-8") == original
     assert config.stat().st_mode & 0o777 == 0o640
     assert list(tmp_path.glob(".config.toml.*.tmp")) == []
+
+
+@pytest.mark.parametrize("final_newline", [True, False])
+def test_codex_install_uninstall_preserves_unrelated_toml_bytes_exactly(
+    tmp_path: Path,
+    monkeypatch,
+    final_newline: bool,
+):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    config = tmp_path / "config.toml"
+    original = (
+        "# Leading user comment\r\n"
+        'notify  = [ "previous-notifier", "--flag" ] # keep inline comment\r\n'
+        'model_provider= "custom-provider"   # preserve spacing\r\n'
+        'model = "gpt-test"\r\n'
+        "\r\n"
+        '[profiles."développement"]\r\n'
+        'approval_policy = "never"'
+    )
+    if final_newline:
+        original += "\r\n"
+    config.write_bytes(original.encode("utf-8"))
+
+    install_codex("http://127.0.0.1:8100", "session ü")
+    installed = config.read_bytes()
+    install_codex("http://127.0.0.1:8100", "session ü")
+    assert config.read_bytes() == installed
+    installed_text = installed.decode("utf-8")
+    assert "# Leading user comment\r\n" in installed_text
+    assert '[profiles."développement"]\r\n' in installed_text
+    assert 'approval_policy = "never"' in installed_text
+
+    uninstall_codex()
+    assert config.read_bytes() == original.encode("utf-8")
+
+
+def test_codex_uninstall_restores_legacy_managed_values(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "# >>> openai-cost-calculator\n"
+        '# previous_notify = notify = ["legacy"]\n'
+        '# previous_model_provider = model_provider = "legacy-provider"\n'
+        'notify = ["occ-codex-notify"]\n'
+        'model_provider = "openai_cost_calculator"\n'
+        "# <<< openai-cost-calculator\n\n"
+        "# >>> openai-cost-calculator\n"
+        "[model_providers.openai_cost_calculator]\n"
+        'name = "managed"\n'
+        "# <<< openai-cost-calculator\n\n"
+        'model = "gpt-test"\n',
+        encoding="utf-8",
+    )
+
+    uninstall_codex()
+    restored = config.read_text(encoding="utf-8")
+    assert 'notify = ["legacy"]' in restored
+    assert 'model_provider = "legacy-provider"' in restored
+    assert 'model = "gpt-test"' in restored
+
+
+def test_codex_stashed_notifier_remains_chainable_and_user_edits_survive(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    config = tmp_path / "config.toml"
+    original = (
+        'notify = ["previous-notifier", "--flag"] # retained\n'
+        'model_provider = "custom"\n'
+        "[features]\n"
+        "web_search = true\n"
+    )
+    config.write_text(original, encoding="utf-8")
+    install_codex("http://127.0.0.1:8100", "s1")
+
+    settings = _codex_adapter_settings()
+    assert settings["previous_notify"] == (
+        'notify = ["previous-notifier", "--flag"] # retained'
+    )
+    with config.open("a", encoding="utf-8") as handle:
+        handle.write("# user edit after installation\n")
+
+    uninstall_codex()
+    assert config.read_text(encoding="utf-8") == (
+        original + "# user edit after installation\n"
+    )

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -308,7 +308,7 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
     assert 'base_url = "http://127.0.0.1:8100/v1"' in text
     assert "requires_openai_auth = true" in text
     assert 'env_key = "OPENAI_API_KEY"' not in text
-    assert "supports_websockets = false" in text
+    assert "supports_websockets = true" in text
     assert 'http_headers = { "X-OCC-Session" = "s1" }' in text
     active_notify_lines = [
         line for line in text.splitlines() if line.startswith('notify = ["')

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -286,6 +286,7 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
     uninstall_claude_code()
     settings = json.loads(claude_settings.read_text(encoding="utf-8"))
     assert settings == {"unrelated": True}
+    assert list(claude_dir.glob("*.occ-backup-*")) == []
 
     codex_dir = tmp_path / ".codex"
     codex_dir.mkdir()
@@ -322,6 +323,7 @@ def test_installers_are_idempotent_and_reversible(tmp_path: Path, monkeypatch):
         'notify = ["existing-notifier"]\n'
         'model = "gpt-test"'
     )
+    assert list(codex_dir.glob("*.occ-backup-*")) == []
 
 
 def test_codex_installer_refuses_invalid_config_without_modifying_it(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -339,3 +339,64 @@ def test_codex_installer_refuses_invalid_config_without_modifying_it(
     assert config.read_text(encoding="utf-8") == original
     assert list(tmp_path.glob("config.toml.occ-backup-*")) == []
     assert list(tmp_path.glob(".config.toml.*.tmp")) == []
+
+
+def test_codex_installer_refuses_conflicting_provider_and_malformed_markers(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    config = tmp_path / "config.toml"
+    conflicting = (
+        "[model_providers.openai_cost_calculator]\n"
+        'name = "user-owned"\n'
+    )
+    config.write_text(conflicting, encoding="utf-8")
+    with pytest.raises(ValueError, match="Refusing to overwrite existing Codex provider"):
+        install_codex("http://127.0.0.1:8100", "s1")
+    assert config.read_text(encoding="utf-8") == conflicting
+
+    malformed = "# >>> openai-cost-calculator\nmodel = \"gpt-test\"\n"
+    config.write_text(malformed, encoding="utf-8")
+    with pytest.raises(ValueError, match="unmatched start marker"):
+        uninstall_codex()
+    assert config.read_text(encoding="utf-8") == malformed
+
+
+def test_codex_installer_refuses_symlink_and_preserves_target(
+    tmp_path: Path,
+    monkeypatch,
+):
+    codex_home = tmp_path / "Codex üser"
+    codex_home.mkdir()
+    target = tmp_path / "actual-config.toml"
+    target.write_text('model = "gpt-test"\n', encoding="utf-8")
+    (codex_home / "config.toml").symlink_to(target)
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    with pytest.raises(ValueError, match="symlinked configuration"):
+        install_codex("http://127.0.0.1:8100", "session ü")
+
+    assert target.read_text(encoding="utf-8") == 'model = "gpt-test"\n'
+
+
+def test_codex_atomic_write_failure_preserves_original_and_cleans_temp(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    config = tmp_path / "config.toml"
+    original = 'model = "gpt-test"\n'
+    config.write_text(original, encoding="utf-8")
+    config.chmod(0o640)
+
+    def interrupted_replace(source, destination):
+        raise OSError("simulated interruption")
+
+    monkeypatch.setattr("os.replace", interrupted_replace)
+    with pytest.raises(OSError, match="simulated interruption"):
+        install_codex("http://127.0.0.1:8100", "s1")
+
+    assert config.read_text(encoding="utf-8") == original
+    assert config.stat().st_mode & 0o777 == 0o640
+    assert list(tmp_path.glob(".config.toml.*.tmp")) == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from openai_cost_calculator.cli import main
+import pytest
+
+from openai_cost_calculator.cli import (
+    _load_admin_token,
+    _validate_proxy_exposure,
+    main,
+)
 
 
 class _Response:
@@ -96,3 +102,27 @@ def test_pricing_validate_cli_and_incompatible_proxy_config(capsys):
         ]
     ) == 2
     assert "incompatible" in capsys.readouterr().err
+
+
+def test_remote_binding_requires_explicit_permission_and_admin_token():
+    with pytest.raises(ValueError, match="--allow-remote"):
+        _validate_proxy_exposure("0.0.0.0", False, None)
+    with pytest.raises(ValueError, match="requires OCC_ADMIN_TOKEN"):
+        _validate_proxy_exposure("::", True, None)
+
+    _validate_proxy_exposure("0.0.0.0", True, "x" * 32)
+    _validate_proxy_exposure("127.0.0.1", False, None)
+    _validate_proxy_exposure("::1", False, None)
+
+
+def test_admin_token_file_must_be_protected(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("OCC_ADMIN_TOKEN", raising=False)
+    monkeypatch.delenv("OCC_ADMIN_TOKEN_FILE", raising=False)
+    token_file = tmp_path / "admin-token"
+    token_file.write_text("t" * 32 + "\n", encoding="utf-8")
+    token_file.chmod(0o600)
+    assert _load_admin_token(str(token_file)) == "t" * 32
+
+    token_file.chmod(0o644)
+    with pytest.raises(ValueError, match="group or others"):
+        _load_admin_token(str(token_file))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,18 @@ def test_ledger_cli_inspects_and_resets_offline_state(tmp_path: Path, capsys):
     assert main(["ledger", "reset", str(path), "--yes"]) == 0
 
 
+def test_database_cli_inspects_and_resets_concurrent_state(tmp_path: Path, capsys):
+    path = tmp_path / "accounting.sqlite3"
+    assert main(["database", "inspect", str(path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sessions"] == {}
+    assert payload["persistence"]["backend"] == "sqlite"
+
+    assert main(["database", "reset", str(path)]) == 2
+    assert "without --yes" in capsys.readouterr().err
+    assert main(["database", "reset", str(path), "--yes"]) == 0
+
+
 def test_pricing_validate_cli_and_incompatible_proxy_config(capsys):
     assert main(["pricing", "validate"]) == 0
     assert "Pricing data valid" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,7 +53,10 @@ def test_status_exposes_latest_call_diagnostics_and_routing(monkeypatch, capsys)
         "persistence": {"enabled": False, "healthy": True},
     }
 
+    monkeypatch.setenv("OCC_ADMIN_TOKEN", "s" * 32)
+
     def urlopen(request, timeout):
+        assert request.headers["Authorization"] == f"Bearer {'s' * 32}"
         return _Response(health if request.full_url.endswith("/_occ/health") else costs)
 
     monkeypatch.setattr("urllib.request.urlopen", urlopen)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openai_cost_calculator.cli import main
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_status_exposes_latest_call_diagnostics_and_routing(monkeypatch, capsys):
+    costs = {
+        "sessions": {
+            "s1": {
+                "session_total": "0.01000000",
+                "historical_total": "0.00400000",
+                "process_total": "0.00600000",
+                "latest_call": {
+                    "model": "gpt-test",
+                    "cost": {"total_cost": "0.00600000"},
+                },
+                "errors": [{"code": "missing_usage", "message": "no usage"}],
+            }
+        },
+        "grand_total": "0.01000000",
+        "persistence": {"enabled": False, "healthy": True},
+    }
+    health = {
+        "ok": True,
+        "routing": {
+            "auth_mode": "api-key",
+            "upstream_category": "platform",
+            "explicit_override": False,
+        },
+        "persistence": {"enabled": False, "healthy": True},
+    }
+
+    def urlopen(request, timeout):
+        return _Response(health if request.full_url.endswith("/_occ/health") else costs)
+
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+    assert main(["status", "--session", "s1", "--diagnostics"]) == 0
+    output = capsys.readouterr().out
+    assert "s1: total $0.01000000" in output
+    assert "latest gpt-test $0.00600000" in output
+    assert "diagnostic missing_usage: no usage" in output
+    assert "auth=api-key, upstream=platform" in output
+
+
+def test_ledger_cli_inspects_and_resets_offline_state(tmp_path: Path, capsys):
+    path = tmp_path / "ledger.json"
+    assert main(["ledger", "inspect", str(path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["sessions"] == {}
+
+    assert main(["ledger", "reset", str(path)]) == 2
+    assert "without --yes" in capsys.readouterr().err
+    assert main(["ledger", "reset", str(path), "--yes"]) == 0
+
+
+def test_pricing_validate_cli_and_incompatible_proxy_config(capsys):
+    assert main(["pricing", "validate"]) == 0
+    assert "Pricing data valid" in capsys.readouterr().out
+
+    assert main(
+        [
+            "proxy",
+            "--auth-mode",
+            "chatgpt",
+            "--upstream",
+            "https://api.openai.com/v1",
+        ]
+    ) == 2
+    assert "incompatible" in capsys.readouterr().err

--- a/tests/test_cost_estimator.py
+++ b/tests/test_cost_estimator.py
@@ -70,6 +70,31 @@ def test_calculate_cost_basic_rounding():
     }
 
 
+def test_calculate_cost_rejects_malformed_usage_and_accepts_free_cache():
+    rates = {"input_price": 1, "cached_input_price": 0, "output_price": 2}
+    free_cache = calculate_cost_typed(
+        {"prompt_tokens": 100, "completion_tokens": 0, "cached_tokens": 100},
+        rates,
+    )
+    assert free_cache.total_cost == Decimal("0")
+
+    with pytest.raises(ValueError, match="cannot exceed"):
+        calculate_cost_typed(
+            {"prompt_tokens": 99, "completion_tokens": 0, "cached_tokens": 100},
+            rates,
+        )
+    with pytest.raises(ValueError, match="non-negative integer"):
+        calculate_cost_typed(
+            {"prompt_tokens": -1, "completion_tokens": 0, "cached_tokens": 0},
+            rates,
+        )
+    with pytest.raises(ValueError, match="finite"):
+        calculate_cost_typed(
+            {"prompt_tokens": 1, "completion_tokens": 0, "cached_tokens": 0},
+            {**rates, "input_price": float("inf")},
+        )
+
+
 def test_calculate_cost_typed_basic():
     """Test the new typed cost calculation function."""
     usage  = {"prompt_tokens": 1_000, "completion_tokens": 2_000, "cached_tokens": 200}
@@ -456,13 +481,13 @@ def test_add_pricing_entries_bulk_and_replace_flag():
 
     # Replace = True should update
     pricing.add_pricing_entries([
-        ("m1", "2025-01-01", 1.1, 2.2, 0.0),  # 0.0 → None
+        ("m1", "2025-01-01", 1.1, 2.2, 0.0),
         ("m1", "2025-01-01", 1.9, 2.9, 0.9, 200000),  # tiered tuple format
     ], replace=True)
 
     d2 = pricing.load_pricing()
     assert d2[("m1", "2025-01-01")] == {
-        "input_price": 1.1, "cached_input_price": None, "output_price": 2.2
+        "input_price": 1.1, "cached_input_price": 0.0, "output_price": 2.2
     }
     assert pricing.load_pricing_tiered()[("m1", "2025-01-01")][1]["minimum_tokens"] == 200000
 
@@ -604,9 +629,39 @@ def test_set_offline_mode_refresh_noop(monkeypatch):
     pricing.refresh_pricing()
     assert pricing.load_pricing() == {}
 
-    # Add an entry with cached_input_price=0 (treated as None)
+    # A zero cached-input price represents free cached input.
     pricing.add_pricing_entry("y", "2025-03-03", input_price=0.2, output_price=0.4, cached_input_price=0.0)
     d = pricing.load_pricing()
     assert d[("y", "2025-03-03")] == {
-        "input_price": 0.2, "cached_input_price": None, "output_price": 0.4
+        "input_price": 0.2, "cached_input_price": 0.0, "output_price": 0.4
     }
+
+
+@pytest.mark.parametrize(
+    "rows, message",
+    [
+        (["x,2025-02-30,0.5,0.1,1.0,0"], "model_date"),
+        (["x,2025-01-01,nan,0.1,1.0,0"], "finite"),
+        (["x,2025-01-01,0.5,0.1,1.0,100"], "no base tier"),
+        (
+            [
+                "x,2025-01-01,0.5,0.1,1.0,0",
+                "x,2025-01-01,0.6,0.1,1.0,0",
+            ],
+            "duplicate tier",
+        ),
+    ],
+)
+def test_pricing_loader_rejects_invalid_rows(monkeypatch, rows, message):
+    importlib.reload(occ.pricing)
+    pricing = occ.pricing
+
+    class _Resp:
+        text = _csv_text_with_minimum(rows)
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(pricing.requests, "get", lambda url, timeout: _Resp())
+    with pytest.raises(ValueError, match=message):
+        pricing.load_pricing_tiered()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -148,3 +148,80 @@ def test_registry_capacity_failure_is_explicit(monkeypatch):
     session = registry.summary("bounded")["sessions"]["bounded"]
     assert session["session_total"] == "0.00100000"
     assert session["errors"][-1]["code"] == "accounting_capacity_reached"
+
+
+def test_sqlite_database_supports_concurrent_proxies_and_atomic_checkpoint(
+    tmp_path: Path,
+):
+    path = tmp_path / "accounting.sqlite3"
+    first = TrackerRegistry(database_path=path)
+    second = TrackerRegistry(database_path=path)
+    usage = {"prompt_tokens": 1000, "completion_tokens": 0, "cached_tokens": 0}
+
+    assert first.record_call(
+        "shared",
+        "gpt-test-2025-01-01",
+        usage,
+        turn_label="first",
+    ) is not None
+    assert second.record_call(
+        "shared",
+        "gpt-test-2025-01-01",
+        usage,
+        turn_label="second",
+    ) is not None
+
+    summary = first.summary("shared")
+    session = summary["sessions"]["shared"]
+    assert session["session_total"] == "0.00200000"
+    assert [turn["label"] for turn in session["turns"]] == ["first", "second"]
+    assert summary["persistence"]["backend"] == "sqlite"
+    assert summary["persistence"]["concurrency"] == "multi-proxy"
+
+    checkpoint = first.checkpoint("shared")
+    assert checkpoint["num_calls"] == 2
+    assert second.checkpoint("shared")["num_calls"] == 0
+    assert path.stat().st_mode & 0o777 == 0o600
+    first.close()
+    second.close()
+
+
+def test_sqlite_database_restores_exact_costs_and_reset_is_transactional(
+    tmp_path: Path,
+):
+    path = tmp_path / "accounting.sqlite3"
+    registry = TrackerRegistry(database_path=path)
+    registry.record_call(
+        "persisted",
+        "gpt-test-2025-01-01",
+        {"prompt_tokens": 1000, "completion_tokens": 500, "cached_tokens": 100},
+    )
+    registry.record_error("persisted", "test", "retained diagnostic")
+    registry.close()
+
+    restored = TrackerRegistry(database_path=path)
+    session = restored.summary("persisted")["sessions"]["persisted"]
+    assert session["session_total"] == "0.00195000"
+    assert session["historical_total"] == "0.00195000"
+    assert session["errors"][0]["message"] == "retained diagnostic"
+    restored.reset()
+    assert restored.summary()["sessions"] == {}
+    restored.close()
+
+
+def test_sqlite_writes_are_incremental_without_snapshot_rewrites(
+    tmp_path: Path,
+    monkeypatch,
+):
+    registry = TrackerRegistry(database_path=tmp_path / "accounting.sqlite3")
+
+    def unexpected_save(payload):
+        raise AssertionError("SQLite must not rewrite a JSON snapshot")
+
+    monkeypatch.setattr(registry._ledger, "save", unexpected_save, raising=False)
+    assert registry.record_call(
+        "incremental",
+        "gpt-test-2025-01-01",
+        {"prompt_tokens": 1, "completion_tokens": 0, "cached_tokens": 0},
+    ) is not None
+    registry.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -218,10 +218,33 @@ def test_sqlite_writes_are_incremental_without_snapshot_rewrites(
     def unexpected_save(payload):
         raise AssertionError("SQLite must not rewrite a JSON snapshot")
 
+    def unexpected_load():
+        raise AssertionError("SQLite summaries must not reconstruct call records")
+
     monkeypatch.setattr(registry._ledger, "save", unexpected_save, raising=False)
+    monkeypatch.setattr(registry._ledger, "load", unexpected_load)
     assert registry.record_call(
         "incremental",
         "gpt-test-2025-01-01",
         {"prompt_tokens": 1, "completion_tokens": 0, "cached_tokens": 0},
     ) is not None
+    assert registry.summary("incremental")["sessions"]["incremental"]["session_total"] == (
+        "0.00000100"
+    )
+    registry.close()
+
+
+def test_sqlite_history_is_not_limited_by_in_memory_call_capacity(
+    tmp_path: Path,
+    monkeypatch,
+):
+    import openai_cost_calculator.proxy.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "_MAX_CALLS_PER_SESSION", 1)
+    registry = TrackerRegistry(database_path=tmp_path / "accounting.sqlite3")
+    usage = {"prompt_tokens": 1, "completion_tokens": 0, "cached_tokens": 0}
+    assert registry.record_call("long-lived", "gpt-test-2025-01-01", usage) is not None
+    assert registry.record_call("long-lived", "gpt-test-2025-01-01", usage) is not None
+    session = registry.summary("long-lived")["sessions"]["long-lived"]
+    assert session["turns"][0]["num_calls"] == 2
     registry.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openai_cost_calculator.pricing import (
+    add_pricing_entry,
+    clear_local_pricing,
+    set_offline_mode,
+)
+from openai_cost_calculator.proxy.ledger import DurableLedger, LedgerError
+from openai_cost_calculator.proxy.registry import TrackerRegistry
+
+
+@pytest.fixture(autouse=True)
+def pinned_pricing():
+    clear_local_pricing()
+    set_offline_mode(True)
+    add_pricing_entry(
+        "gpt-test",
+        "2025-01-01",
+        input_price=1.0,
+        output_price=2.0,
+        cached_input_price=0.5,
+    )
+    yield
+    clear_local_pricing()
+    set_offline_mode(False)
+
+
+def test_durable_ledger_restores_costs_diagnostics_and_checkpoint(tmp_path: Path):
+    path = tmp_path / "accounting.json"
+    first = TrackerRegistry(ledger_path=path)
+    first.record_call(
+        "session-a",
+        "gpt-test-2025-01-01",
+        {"prompt_tokens": 1000, "completion_tokens": 500, "cached_tokens": 100},
+        turn_label="turn-1",
+    )
+    first.record_error("session-a", "test_diagnostic", "observable")
+    consumed = first.checkpoint("session-a")
+    assert consumed["num_calls"] == 1
+    first.close()
+
+    second = TrackerRegistry(ledger_path=path)
+    restored = second.summary("session-a")
+    session = restored["sessions"]["session-a"]
+    assert session["session_total"] == "0.00195000"
+    assert session["historical_total"] == "0.00195000"
+    assert session["process_total"] == "0.00000000"
+    assert session["latest_call"]["model"] == "gpt-test-2025-01-01"
+    assert session["errors"][0]["code"] == "test_diagnostic"
+    assert second.checkpoint("session-a")["num_calls"] == 0
+
+    second.record_call(
+        "session-a",
+        "gpt-test-2025-01-01",
+        {"prompt_tokens": 0, "completion_tokens": 1000, "cached_tokens": 0},
+        turn_label="turn-2",
+    )
+    updated = second.summary("session-a")["sessions"]["session-a"]
+    assert updated["historical_total"] == "0.00195000"
+    assert updated["process_total"] == "0.00200000"
+    assert second.checkpoint("session-a")["num_calls"] == 1
+    second.close()
+
+
+def test_durable_ledger_uses_atomic_replacement_and_cleans_interrupted_temp(
+    tmp_path: Path,
+):
+    path = tmp_path / "accounting.json"
+    path.write_text('{"schema_version":1,"sessions":{}}\n', encoding="utf-8")
+    interrupted = tmp_path / ".accounting.json.abandoned.tmp"
+    interrupted.write_text("partial", encoding="utf-8")
+
+    ledger = DurableLedger(path)
+    assert not interrupted.exists()
+    ledger.save({"schema_version": 1, "sessions": {"safe": {}}})
+    assert json.loads(path.read_text(encoding="utf-8"))["sessions"] == {"safe": {}}
+    assert path.stat().st_mode & 0o777 == 0o600
+    ledger.close()
+
+
+def test_durable_ledger_rejects_concurrent_writer_and_corrupt_data(tmp_path: Path):
+    path = tmp_path / "accounting.json"
+    first = DurableLedger(path)
+    with pytest.raises(LedgerError, match="already in use"):
+        DurableLedger(path)
+    first.close()
+
+    path.write_text("not json", encoding="utf-8")
+    corrupt = DurableLedger(path)
+    with pytest.raises(LedgerError, match="not valid JSON"):
+        corrupt.load()
+    corrupt.close()
+
+
+def test_failed_ledger_write_is_visible_and_does_not_consume_checkpoint(
+    tmp_path: Path,
+    monkeypatch,
+):
+    registry = TrackerRegistry(ledger_path=tmp_path / "accounting.json")
+
+    def fail_save(payload):
+        raise LedgerError("simulated interrupted write")
+
+    monkeypatch.setattr(registry._ledger, "save", fail_save)
+    record = registry.record_call(
+        "session-a",
+        "gpt-test-2025-01-01",
+        {"prompt_tokens": 1000, "completion_tokens": 0, "cached_tokens": 0},
+    )
+    assert record is not None
+    assert registry.persistence_status()["healthy"] is False
+    with pytest.raises(LedgerError, match="not consumed"):
+        registry.checkpoint("session-a")
+    assert registry._checkpoint_cursors["session-a"] == 0
+    registry.close()
+
+
+def test_reset_is_durable_across_restart(tmp_path: Path):
+    path = tmp_path / "accounting.json"
+    registry = TrackerRegistry(ledger_path=path)
+    registry.record_call(
+        "session-a",
+        "gpt-test-2025-01-01",
+        {"prompt_tokens": 1000, "completion_tokens": 0, "cached_tokens": 0},
+    )
+    registry.reset()
+    registry.close()
+
+    restored = TrackerRegistry(ledger_path=path)
+    assert restored.summary()["sessions"] == {}
+    restored.close()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -134,3 +134,17 @@ def test_reset_is_durable_across_restart(tmp_path: Path):
     restored = TrackerRegistry(ledger_path=path)
     assert restored.summary()["sessions"] == {}
     restored.close()
+
+
+def test_registry_capacity_failure_is_explicit(monkeypatch):
+    import openai_cost_calculator.proxy.registry as registry_module
+
+    monkeypatch.setattr(registry_module, "_MAX_CALLS_PER_SESSION", 1)
+    registry = TrackerRegistry()
+    usage = {"prompt_tokens": 1000, "completion_tokens": 0, "cached_tokens": 0}
+    assert registry.record_call("bounded", "gpt-test-2025-01-01", usage) is not None
+    assert registry.record_call("bounded", "gpt-test-2025-01-01", usage) is None
+
+    session = registry.summary("bounded")["sessions"]["bounded"]
+    assert session["session_total"] == "0.00100000"
+    assert session["errors"][-1]["code"] == "accounting_capacity_reached"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -370,3 +370,29 @@ def test_diagnostics_are_sanitized_and_bounded():
     assert errors[0]["message"].startswith("line 5 ")
     assert "secret" not in errors[-1]["message"]
     assert "sk-exampletoken" not in errors[-1]["message"]
+
+
+def test_admin_endpoints_require_configured_bearer_token():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    app = create_app(
+        upstream="https://upstream.example/v1",
+        transport=httpx.MockTransport(handler),
+        registry=TrackerRegistry(),
+        admin_token="a" * 32,
+    )
+    client = ASGITestClient(app)
+
+    unauthorized = client.get("/_occ/costs")
+    assert unauthorized.status_code == 401
+    assert unauthorized.json()["error"]["code"] == "admin_auth_required"
+    assert unauthorized.headers["www-authenticate"] == "Bearer"
+    assert client.post("/_occ/reset", headers={"authorization": "Bearer wrong"}).status_code == 401
+
+    authorized = client.get(
+        "/_occ/costs",
+        headers={"authorization": f"Bearer {'a' * 32}"},
+    )
+    assert authorized.status_code == 200
+    assert authorized.json()["grand_total"] == "0.00000000"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -297,6 +297,8 @@ def test_request_hop_by_hop_headers_are_not_forwarded():
         assert request.headers["x-keep"] == "yes"
         assert "keep-alive" not in request.headers
         assert "x-remove" not in request.headers
+        assert "x-occ-session" not in request.headers
+        assert "x-occ-turn" not in request.headers
         return httpx.Response(500, json={"error": "expected"})
 
     client = _client(handler)
@@ -308,7 +310,62 @@ def test_request_hop_by_hop_headers_are_not_forwarded():
             "keep-alive": "timeout=5",
             "x-remove": "private",
             "x-keep": "yes",
+            "x-occ-session": "local-only",
+            "x-occ-turn": "local-turn",
         },
     )
 
     assert response.status_code == 500
+
+
+def test_stream_parser_handles_fragmented_utf8_crlf_comments_and_multiline_data():
+    payload = {
+        "model": "gpt-test-2025-01-01",
+        "usage": {"input_tokens": 1000, "output_tokens": 500},
+        "note": "£",
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    pound = encoded.index("£".encode("utf-8"))
+    split_json = encoded[: pound + 1], encoded[pound + 1 :]
+    chunks = [
+        b": keep-alive\r",
+        b"\n\r\n",
+        b"data: " + split_json[0],
+        split_json[1] + b"\r\n",
+        b"data:\r\n\r\n",
+        b"data: [DONE]\r\n\r\n",
+    ]
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=AsyncChunkStream(chunks),
+        )
+
+    client = _client(handler)
+    response = client.post(
+        "/v1/responses",
+        json={"model": "gpt-test-2025-01-01", "stream": True},
+        headers={"x-occ-session": "fragmented"},
+    )
+
+    assert response.content == b"".join(chunks)
+    session = client.get("/_occ/costs?session=fragmented").json()["sessions"]["fragmented"]
+    assert session["session_total"] == "0.00200000"
+
+
+def test_diagnostics_are_sanitized_and_bounded():
+    registry = TrackerRegistry()
+    for index in range(105):
+        registry.record_error(
+            "diagnostics",
+            "failure",
+            f"line {index}\nAuthorization: Bearer secret-{index} sk-exampletoken",
+        )
+
+    errors = registry.summary("diagnostics")["sessions"]["diagnostics"]["errors"]
+    assert len(errors) == 100
+    assert errors[0]["message"].startswith("line 5 ")
+    assert "secret" not in errors[-1]["message"]
+    assert "sk-exampletoken" not in errors[-1]["message"]

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -463,7 +463,7 @@ def test_websocket_relay_preserves_frames_headers_query_and_subprotocol():
         },
         separators=(",", ":"),
     )
-    sent_to_upstream = asyncio.Event()
+    sent_to_upstream = None
 
     class FakeUpstream:
         subprotocol = "realtime"
@@ -475,6 +475,7 @@ def test_websocket_relay_preserves_frames_headers_query_and_subprotocol():
 
         async def send(self, payload):
             self.sent.append(payload)
+            assert sent_to_upstream is not None
             sent_to_upstream.set()
 
         def __aiter__(self):
@@ -483,6 +484,7 @@ def test_websocket_relay_preserves_frames_headers_query_and_subprotocol():
         async def __anext__(self):
             if self._yielded:
                 raise StopAsyncIteration
+            assert sent_to_upstream is not None
             await sent_to_upstream.wait()
             self._yielded = True
             return upstream_frame
@@ -549,7 +551,13 @@ def test_websocket_relay_preserves_frames_headers_query_and_subprotocol():
         websocket_connector=connector,
     )
     websocket = FakeClientWebSocket()
-    asyncio.run(_forward_websocket(app, "responses", websocket))
+
+    async def exercise_relay():
+        nonlocal sent_to_upstream
+        sent_to_upstream = asyncio.Event()
+        await _forward_websocket(app, "responses", websocket)
+
+    asyncio.run(exercise_relay())
 
     assert connection["url"] == "wss://upstream.example/v1/responses?beta=1"
     headers = dict(connection["kwargs"]["additional_headers"])

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -4,7 +4,8 @@ import json
 
 import httpx
 import pytest
-from fastapi.testclient import TestClient
+
+from asgi_client import ASGITestClient
 
 from openai_cost_calculator.parser import extract_usage_from_payload
 from openai_cost_calculator.pricing import (
@@ -48,7 +49,7 @@ def _client(handler):
         transport=transport,
         registry=TrackerRegistry(),
     )
-    return TestClient(app)
+    return ASGITestClient(app)
 
 
 def test_extract_usage_from_payload_supports_chat_and_responses_shapes():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 import httpx
@@ -14,7 +15,12 @@ from openai_cost_calculator.pricing import (
     set_offline_mode,
 )
 from openai_cost_calculator.proxy.app import create_app
+from openai_cost_calculator.proxy.app import (
+    _WebSocketAccountingObserver,
+    _forward_websocket,
+)
 from openai_cost_calculator.proxy.registry import TrackerRegistry
+from starlette.datastructures import Headers, URL
 
 
 class AsyncChunkStream(httpx.AsyncByteStream):
@@ -396,3 +402,164 @@ def test_admin_endpoints_require_configured_bearer_token():
     )
     assert authorized.status_code == 200
     assert authorized.json()["grand_total"] == "0.00000000"
+
+
+def test_websocket_observer_costs_terminal_usage_once_and_reports_failures():
+    registry = TrackerRegistry()
+    observer = _WebSocketAccountingObserver(
+        registry,
+        session_id="websocket",
+        turn_label="turn-1",
+    )
+    observer.observe_client(
+        json.dumps(
+            {
+                "type": "response.create",
+                "response": {"model": "gpt-test-2025-01-01"},
+            }
+        )
+    )
+    completed = json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "response-1",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        }
+    )
+    observer.observe_upstream(completed)
+    observer.observe_upstream(completed.encode("utf-8"))
+    observer.observe_upstream(
+        json.dumps(
+            {
+                "type": "response.failed",
+                "response": {"id": "response-2"},
+            }
+        )
+    )
+
+    session = registry.summary("websocket")["sessions"]["websocket"]
+    assert session["session_total"] == "0.00200000"
+    assert session["turns"][0]["num_calls"] == 1
+    assert session["errors"][-1]["code"] == "websocket_response_failed"
+
+
+def test_websocket_relay_preserves_frames_headers_query_and_subprotocol():
+    client_frame = json.dumps(
+        {
+            "type": "response.create",
+            "response": {"model": "gpt-test-2025-01-01"},
+        },
+        separators=(",", ":"),
+    )
+    upstream_frame = json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "response-relay",
+                "usage": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        },
+        separators=(",", ":"),
+    )
+    sent_to_upstream = asyncio.Event()
+
+    class FakeUpstream:
+        subprotocol = "realtime"
+
+        def __init__(self):
+            self.sent = []
+            self.closed = None
+            self._yielded = False
+
+        async def send(self, payload):
+            self.sent.append(payload)
+            sent_to_upstream.set()
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._yielded:
+                raise StopAsyncIteration
+            await sent_to_upstream.wait()
+            self._yielded = True
+            return upstream_frame
+
+        async def close(self, code=1000, reason=""):
+            self.closed = (code, reason)
+
+    upstream = FakeUpstream()
+    connection = {}
+
+    class ConnectionContext:
+        async def __aenter__(self):
+            return upstream
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    def connector(url, **kwargs):
+        connection["url"] = url
+        connection["kwargs"] = kwargs
+        return ConnectionContext()
+
+    class FakeClientWebSocket:
+        headers = Headers(
+            raw=[
+                (b"authorization", b"Bearer upstream-token"),
+                (b"x-occ-session", b"websocket-relay"),
+                (b"x-occ-turn", b"relay-turn"),
+                (b"sec-websocket-protocol", b"realtime"),
+                (b"connection", b"upgrade"),
+                (b"upgrade", b"websocket"),
+            ]
+        )
+        url = URL("ws://proxy.example/v1/responses?beta=1")
+
+        def __init__(self):
+            self.accepted = None
+            self.sent = []
+            self.closed = None
+            self._received = False
+
+        async def accept(self, subprotocol=None):
+            self.accepted = subprotocol
+
+        async def receive(self):
+            if not self._received:
+                self._received = True
+                return {"type": "websocket.receive", "text": client_frame}
+            await asyncio.Future()
+
+        async def send_text(self, payload):
+            self.sent.append(payload)
+
+        async def send_bytes(self, payload):
+            self.sent.append(payload)
+
+        async def close(self, code=1000, reason=""):
+            self.closed = (code, reason)
+
+    registry = TrackerRegistry()
+    app = create_app(
+        upstream="https://upstream.example/v1",
+        registry=registry,
+        websocket_connector=connector,
+    )
+    websocket = FakeClientWebSocket()
+    asyncio.run(_forward_websocket(app, "responses", websocket))
+
+    assert connection["url"] == "wss://upstream.example/v1/responses?beta=1"
+    headers = dict(connection["kwargs"]["additional_headers"])
+    assert headers["authorization"] == "Bearer upstream-token"
+    assert "x-occ-session" not in headers
+    assert "connection" not in headers
+    assert connection["kwargs"]["subprotocols"] == ["realtime"]
+    assert upstream.sent == [client_frame]
+    assert websocket.sent == [upstream_frame]
+    assert websocket.accepted == "realtime"
+    assert websocket.closed == (1000, "")
+    session = registry.summary("websocket-relay")["sessions"]["websocket-relay"]
+    assert session["session_total"] == "0.00200000"

--- a/tests/test_self_test.py
+++ b/tests/test_self_test.py
@@ -15,6 +15,10 @@ self_test = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(self_test)
 
 
+def test_self_test_has_toml_parser_on_all_supported_python_versions():
+    assert self_test.tomllib.loads('model = "gpt-test"') == {"model": "gpt-test"}
+
+
 def test_explicit_api_key_mode_uses_stdin_and_ignores_source_chatgpt_login(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_self_test.py
+++ b/tests/test_self_test.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "self_test_codex_integration.py"
+SPEC = importlib.util.spec_from_file_location("occ_self_test", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+self_test = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(self_test)
+
+
+def test_explicit_api_key_mode_uses_stdin_and_ignores_source_chatgpt_login(
+    tmp_path: Path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    source = home / ".codex"
+    source.mkdir(parents=True)
+    (source / "auth.json").write_text(
+        json.dumps({"auth_mode": "chatgpt", "token": "source-secret"}),
+        encoding="utf-8",
+    )
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("OPENAI_API_KEY", "api-key-secret")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    method, mode = self_test._prepare_auth(
+        isolated,
+        Path("codex"),
+        requested_mode="api-key",
+    )
+
+    assert mode == "api-key"
+    assert method == "OPENAI_API_KEY imported into isolated Codex login"
+    assert calls[0][0] == ["codex", "login", "--with-api-key"]
+    assert calls[0][1]["input"] == "api-key-secret"
+    assert "api-key-secret" not in calls[0][0]
+    assert not (isolated / "auth.json").exists()
+
+
+def test_explicit_chatgpt_mode_requires_and_copies_chatgpt_login(
+    tmp_path: Path,
+    monkeypatch,
+):
+    home = tmp_path / "home"
+    source = home / ".codex"
+    source.mkdir(parents=True)
+    auth = source / "auth.json"
+    auth.write_text(json.dumps({"auth_mode": "chatgpt"}), encoding="utf-8")
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    method, mode = self_test._prepare_auth(
+        isolated,
+        Path("codex"),
+        requested_mode="chatgpt",
+    )
+    assert mode == "chatgpt"
+    assert method == "isolated copy of existing Codex login"
+    assert (isolated / "auth.json").stat().st_mode & 0o777 == 0o600
+
+
+def test_explicit_api_key_mode_fails_cleanly_without_key(tmp_path: Path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    isolated = tmp_path / "isolated"
+    isolated.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    with pytest.raises(self_test.SelfTestError, match="requires OPENAI_API_KEY"):
+        self_test._prepare_auth(
+            isolated,
+            Path("codex"),
+            requested_mode="api-key",
+        )

--- a/tests/test_upstreams.py
+++ b/tests/test_upstreams.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openai_cost_calculator.proxy.upstreams import (
+    CHATGPT_CODEX_UPSTREAM,
+    PLATFORM_UPSTREAM,
+    UpstreamSelectionError,
+    resolve_upstream,
+)
+
+
+def _auth_home(tmp_path: Path, mode: str) -> Path:
+    home = tmp_path / mode
+    home.mkdir()
+    (home / "auth.json").write_text(
+        json.dumps({"auth_mode": mode, "tokens": {"access_token": "not-read"}}),
+        encoding="utf-8",
+    )
+    return home
+
+
+def test_auto_selection_distinguishes_chatgpt_and_api_key_auth(tmp_path: Path):
+    chatgpt = resolve_upstream(codex_home=_auth_home(tmp_path, "chatgpt"))
+    assert chatgpt.auth_mode == "chatgpt"
+    assert chatgpt.category == "chatgpt-codex"
+    assert chatgpt.url == CHATGPT_CODEX_UPSTREAM
+    assert chatgpt.explicit_override is False
+
+    api_key = resolve_upstream(codex_home=_auth_home(tmp_path, "api"))
+    assert api_key.auth_mode == "api-key"
+    assert api_key.category == "platform"
+    assert api_key.url == PLATFORM_UPSTREAM
+
+
+def test_explicit_custom_upstream_is_observable_and_credentials_are_rejected():
+    selection = resolve_upstream(
+        auth_mode="api-key",
+        upstream="https://gateway.example/openai/v1/",
+    )
+    assert selection.category == "custom"
+    assert selection.explicit_override is True
+    assert selection.url == "https://gateway.example/openai/v1"
+
+    with pytest.raises(UpstreamSelectionError, match="must not contain credentials"):
+        resolve_upstream(
+            auth_mode="api-key",
+            upstream="https://user:secret@gateway.example/v1",
+        )
+
+
+@pytest.mark.parametrize(
+    "auth_mode, upstream, expected",
+    [
+        ("chatgpt", PLATFORM_UPSTREAM, "ChatGPT-backed"),
+        ("api-key", CHATGPT_CODEX_UPSTREAM, "API-key"),
+    ],
+)
+def test_known_incompatible_authentication_domains_are_rejected(
+    auth_mode,
+    upstream,
+    expected,
+):
+    with pytest.raises(UpstreamSelectionError, match=expected):
+        resolve_upstream(auth_mode=auth_mode, upstream=upstream)
+
+
+def test_auto_without_auth_metadata_keeps_platform_compatible_default(
+    tmp_path: Path,
+    monkeypatch,
+):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    selection = resolve_upstream(codex_home=tmp_path)
+    assert selection.auth_mode == "unspecified"
+    assert selection.category == "platform"
+    assert selection.url == PLATFORM_UPSTREAM


### PR DESCRIPTION
## Summary
Hardens the Codex cost-observation integration for production use with trustworthy accounting, safer configuration handling, explicit routing, and stronger operational visibility.

## What changed
Adds validated pricing and streaming diagnostics, centralized ChatGPT/API-key upstream selection, durable JSON and concurrent SQLite ledgers, bounded state and atomic checkpoints, authenticated remote administration, Responses WebSocket observation as an explicit opt-in, byte-preserving reversible TOML installation, expanded CLI operations, an explicit API-key self-test mode, and updated documentation.

## Testing performed
Ran the focused suite (`39 passed`), the complete suite with warnings as errors (`96 passed`), isolated Python 3.9 and 3.10 suites (`96 passed` each), all eight GitHub Actions jobs across macOS/Ubuntu and Python 3.9–3.12, CLI/import/dependency/build smoke checks, and one live ChatGPT-backed Codex request whose independently recomputed `$0.014131` cost matched request, session, checkpoint, and status-line totals.

## Risk / rollback notes
Defaults remain in-memory, loopback-bound, and HTTP-based; SQLite, remote exposure, and WebSockets are opt-in, the legacy JSON backend remains available, and the branch can be reverted without a required data migration.

## Follow-up work
The live Platform API-key route was not run because no key was available, while its login, routing, credential-sanitization, and failure behavior are covered deterministically; existing setuptools metadata warnings can be cleaned up separately.
