### PR TITLE
Reduce GitHub Actions CI costs

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,36 +1,23 @@
-name: Run Tests
+name: Compatibility Tests
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**/*.md"
-      - LICENSE
-      - index.html
-  pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - LICENSE
-      - index.html
+  schedule:
+    - cron: "17 4 1 * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
-  test:
-    name: test (${{ matrix.os }}, py${{ matrix.python-version }})
+  compatibility:
+    name: compatibility (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ${{ fromJSON(github.event_name == 'pull_request' && '["3.11"]' || '["3.9", "3.10", "3.11", "3.12"]') }}
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pricing-check.yml
+++ b/.github/workflows/pricing-check.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   pricing-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Code
@@ -21,11 +22,11 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
+        run: python -m pip install -r requirements.txt
 
       - name: Check Pricing
         run: python scripts/check_pricing.py


### PR DESCRIPTION
## Summary
Reduces GitHub Actions usage by replacing the per-commit cross-platform matrix with fast pull-request validation, broad Linux coverage on `main`, and scheduled compatibility testing.

## What changed
Pull requests now run one Ubuntu/Python 3.11 job, `main` runs Python 3.9-3.12 on Ubuntu, monthly and manual runs cover Ubuntu and macOS across all supported versions, obsolete PR runs are cancelled, documentation-only test runs are skipped, and dependency setup and pricing-check caching are streamlined.

## Testing performed
Validated all workflows with actionlint 1.7.12 and YAML trigger/matrix assertions, and ran all 181 tests successfully on Python 3.9, 3.11, and 3.12; Python 3.10 was unavailable locally but its latest existing GitHub Actions job passed.

## Risk / rollback notes
The existing `test (ubuntu-latest, py3.11)` check name is preserved and no status checks are currently required; Windows remains excluded because the suite contains explicit POSIX-only behavior, and rollback is a revert of commit `45de970`.

## Follow-up work
Review the first `main` matrix run, manually dispatch the compatibility workflow, and compare Actions usage after one billing period.
